### PR TITLE
WIP: A new command to diff two repo versions

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -696,46 +696,7 @@ func (r *repository) GetAllTargetMetadataByName(name string) ([]TargetSignedStru
 	if err := r.Update(false); err != nil {
 		return nil, err
 	}
-
-	var targetInfoList []TargetSignedStruct
-
-	// Define a visitor function to find the specified target
-	getAllTargetInfoByNameVisitorFunc := func(tgt *data.SignedTargets, validRole data.DelegationRole) interface{} {
-		if tgt == nil {
-			return nil
-		}
-		// We found a target and validated path compatibility in our walk,
-		// so add it to our list if we have a match
-		// if we have an empty name, add all targets, else check if we have it
-		var targetMetaToAdd data.Files
-		if name == "" {
-			targetMetaToAdd = tgt.Signed.Targets
-		} else {
-			if meta, ok := tgt.Signed.Targets[name]; ok {
-				targetMetaToAdd = data.Files{name: meta}
-			}
-		}
-
-		for targetName, resultMeta := range targetMetaToAdd {
-			targetInfo := TargetSignedStruct{
-				Role:       validRole,
-				Target:     Target{Name: targetName, Hashes: resultMeta.Hashes, Length: resultMeta.Length, Custom: resultMeta.Custom},
-				Signatures: tgt.Signatures,
-			}
-			targetInfoList = append(targetInfoList, targetInfo)
-		}
-		// continue walking to all child roles
-		return nil
-	}
-
-	// Check that we didn't error, and that we found the target at least once
-	if err := r.tufRepo.WalkTargets(name, "", getAllTargetInfoByNameVisitorFunc); err != nil {
-		return nil, err
-	}
-	if len(targetInfoList) == 0 {
-		return nil, ErrNoSuchTarget(name)
-	}
-	return targetInfoList, nil
+	return getAllTargetMetadataByName(*r.tufRepo, name)
 }
 
 // GetChangelist returns the list of the repository's unpublished changes

--- a/client/diff.go
+++ b/client/diff.go
@@ -1,0 +1,135 @@
+package client
+
+import (
+	"errors"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+
+	store "github.com/theupdateframework/notary/storage"
+	"github.com/theupdateframework/notary/trustpinning"
+	"github.com/theupdateframework/notary/tuf"
+	"github.com/theupdateframework/notary/tuf/data"
+	"github.com/theupdateframework/notary/tuf/utils"
+)
+
+// Diff represents the difference between two versions of the same repo
+type Diff struct {}
+
+// NewDiff returns the different between two versions of the same TUF repo
+func NewDiff(gun data.GUN, baseURL string, rt http.RoundTripper, hash1, hash2 string) (Diff, error) {
+	remoteStore, err := getRemoteStore(baseURL, gun, rt)
+	if err != nil {
+		// baseURL is syntactically invalid
+		return Diff{}, err
+	}
+	
+	first, err := setupClient(gun, hash1, remoteStore)
+	if err != nil {
+		return Diff{}, err
+	}
+	second, err := setupClient(gun, hash2, remoteStore)
+	if err != nil {
+		return Diff{}, err
+	}
+
+	// download the relevant versions of the repos now that we have the bootstrapping
+	// setup. 
+	// N.B. lower case update will fail out immediately rather than attempting
+	//      to download a newer root
+	err = first.update()
+	if err != nil {
+		return Diff{}, errors.New("failed to download repo version " + hash1)
+	}
+	err = second.update()
+	if err != nil {
+		return Diff{}, errors.New("failed to download repo version " + hash2)
+	}
+
+	repoFirst, _, err := first.newBuilder.Finish()
+	repoSecond, _, err := second.newBuilder.Finish()
+
+	return diff(repoFirst, repoSecond)
+}
+
+func setupClient(gun data.GUN, tsHash string, remote store.RemoteStore) (*tufClient, error) {
+	hashBytes, err := hex.DecodeString(tsHash)
+	if err != nil {
+		return nil, err
+	}
+
+	root, err := findRoot(hashBytes, remote)
+
+	oldBuilder := tuf.NewRepoBuilder(gun, nil, trustpinning.TrustPinConfig{})
+	if err := oldBuilder.Load(data.CanonicalRootRole, root, 0, true); err != nil {
+		return nil, err
+	}
+	newBuilder := tuf.NewRepoBuilder(gun, nil, trustpinning.TrustPinConfig{})
+	if err := newBuilder.Load(data.CanonicalRootRole, root, 0, true); err != nil {
+		return nil, err
+	}
+
+	tClient := newTufClient(oldBuilder, newBuilder, remote, store.NewMemoryStore(nil))
+	tClient.tsChecksum = hashBytes
+	return tClient, nil
+}
+
+func diff(first, second *tuf.Repo) (Diff, error) {
+	return Diff{}, nil
+}
+
+// walk ts -> snap -> root.
+// TODO: verify checksums. Other verification will be done when we
+// eventually call tufClient.update()
+func findRoot(tsChecksum []byte, remote store.RemoteStore) ([]byte, error) {
+	consistentTSName := utils.ConsistentName(
+		data.CanonicalTimestampRole.String(),
+		tsChecksum,
+	)
+
+	raw, err := remote.GetSized(consistentTSName, 0)
+	if err != nil {
+		logrus.Debugf("error downloading %s: %s", consistentTSName, err)
+		return nil, err
+	}
+
+	ts := &data.SignedTimestamp{}
+	err = json.Unmarshal(raw, ts)
+	if err != nil {
+		logrus.Debugf("error parsing %s: %s", consistentTSName, err)
+		return nil, err
+	}
+
+	snapshotMeta := ts.Signed.Meta[data.CanonicalSnapshotRole.String()] 
+	consistentSnapshotName := utils.ConsistentName(
+		data.CanonicalSnapshotRole.String(),
+		snapshotMeta.Hashes["sha256"],
+	)
+	raw, err = remote.GetSized(consistentSnapshotName, snapshotMeta.Length)
+	if err != nil {
+		logrus.Debugf("error downloading %s: %s", consistentSnapshotName, err)
+		return nil, err
+	}
+
+	snap := &data.SignedSnapshot{}
+	err = json.Unmarshal(raw, snap)
+	if err != nil {
+		logrus.Debugf("error parsing %s: %s", consistentSnapshotName, err)
+		return nil, err
+	}
+
+	rootMeta := snap.Signed.Meta[data.CanonicalRootRole.String()] 
+	consistentRootName := utils.ConsistentName(
+		data.CanonicalRootRole.String(),
+		rootMeta.Hashes["sha256"],
+	)
+	raw, err = remote.GetSized(consistentRootName, rootMeta.Length)
+	if err != nil {
+		logrus.Debugf("error downloading %s: %s", consistentRootName, err)
+		return nil, err
+	}
+
+	return raw, err
+}

--- a/client/tufclient.go
+++ b/client/tufclient.go
@@ -180,7 +180,7 @@ func (c *tufClient) updateRootVersions(fromVersion, toVersion int) error {
 func (c *tufClient) downloadTimestamp() error {
 	logrus.Debug("Loading timestamp...")
 	var (
-		role = data.CanonicalTimestampRole
+		role           = data.CanonicalTimestampRole
 		consistentInfo tuf.ConsistentInfo
 	)
 
@@ -191,6 +191,7 @@ func (c *tufClient) downloadTimestamp() error {
 				Hashes: data.Hashes{
 					"sha256": c.tsChecksum,
 				},
+				Length: notary.MaxTimestampSize,
 			},
 		)
 	} else {

--- a/client/utils.go
+++ b/client/utils.go
@@ -1,0 +1,48 @@
+package client
+
+import (
+	"github.com/theupdateframework/notary/tuf"
+	"github.com/theupdateframework/notary/tuf/data"
+)
+
+func getAllTargetMetadataByName(repo tuf.Repo, name string) ([]TargetSignedStruct, error) {
+	var targetInfoList []TargetSignedStruct
+
+	// Define a visitor function to find the specified target
+	getAllTargetInfoByNameVisitorFunc := func(tgt *data.SignedTargets, validRole data.DelegationRole) interface{} {
+		if tgt == nil {
+			return nil
+		}
+		// We found a target and validated path compatibility in our walk,
+		// so add it to our list if we have a match
+		// if we have an empty name, add all targets, else check if we have it
+		var targetMetaToAdd data.Files
+		if name == "" {
+			targetMetaToAdd = tgt.Signed.Targets
+		} else {
+			if meta, ok := tgt.Signed.Targets[name]; ok {
+				targetMetaToAdd = data.Files{name: meta}
+			}
+		}
+
+		for targetName, resultMeta := range targetMetaToAdd {
+			targetInfo := TargetSignedStruct{
+				Role:       validRole,
+				Target:     Target{Name: targetName, Hashes: resultMeta.Hashes, Length: resultMeta.Length, Custom: resultMeta.Custom},
+				Signatures: tgt.Signatures,
+			}
+			targetInfoList = append(targetInfoList, targetInfo)
+		}
+		// continue walking to all child roles
+		return nil
+	}
+
+	// Check that we didn't error, and that we found the target at least once
+	if err := repo.WalkTargets(name, "", getAllTargetInfoByNameVisitorFunc); err != nil {
+		return nil, err
+	}
+	if len(targetInfoList) == 0 {
+		return nil, ErrNoSuchTarget(name)
+	}
+	return targetInfoList, nil
+}

--- a/cmd/diff/diff.go
+++ b/cmd/diff/diff.go
@@ -1,0 +1,340 @@
+package main
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"fmt"
+	"time"
+	"path"
+
+	"github.com/docker/distribution/registry/client/auth"
+	"github.com/docker/distribution/registry/client/auth/challenge"
+	"github.com/docker/distribution/registry/client/transport"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/docker/go-connections/tlsconfig"
+
+	"github.com/theupdateframework/notary/tuf/data"
+	"github.com/theupdateframework/notary/passphrase"
+	"github.com/theupdateframework/notary/trustpinning"
+	"github.com/theupdateframework/notary/utils"
+	"github.com/theupdateframework/notary/client"
+)
+
+func (n *notaryCommander) Diff(cmd *cobra.Command, args []string) {
+	cmd.Println("Running diff on", "gun")
+
+	if len(args) < 3 {
+		cmd.Usage()
+		logrus.Fatalf("Must specify a GUN and two timestamp hashes")
+	}
+	config, err := n.parseConfig()
+	if err != nil {
+		logrus.Fatalf(err.Error())
+	}
+	gun := data.GUN(args[0])
+	hash1 := args[1]
+	hash2 := args[2]
+
+	baseURL := getRemoteTrustServer(config)
+
+	rt, err := getTransport(config, gun, admin)
+	if err != nil {
+		logrus.Fatalf(err.Error())
+	}
+
+	diff, err := client.NewDiff(gun, baseURL, rt, hash1, hash2)
+	if err != nil {
+		logrus.Fatalf(err.Error())
+	}
+	out, err := json.Marshal(diff)
+	if err != nil {
+		logrus.Fatalf(err.Error())
+	}
+	cmd.Println(out)
+}
+
+
+type passwordStore struct {
+	anonymous bool
+}
+
+func getUsername(input chan string) {
+	in := bufio.NewReader(os.Stdin)
+	result, err := in.ReadString('\n')
+	if err != nil {
+		logrus.Errorf("error processing username input: %s", err)
+		input <- ""
+	}
+	input <- result
+}
+
+func (ps passwordStore) Basic(u *url.URL) (string, string) {
+	// if it's not a terminal, don't wait on input
+	if ps.anonymous {
+		return "", ""
+	}
+
+	auth := os.Getenv("NOTARY_AUTH")
+	if auth != "" {
+		dec, err := base64.StdEncoding.DecodeString(auth)
+		if err != nil {
+			logrus.Error("Could not base64-decode authentication string")
+			return "", ""
+		}
+		plain := string(dec)
+
+		i := strings.Index(plain, ":")
+		if i == 0 {
+			logrus.Error("Authentication string with zero-legnth username")
+			return "", ""
+		} else if i > -1 {
+			username := plain[:i]
+			password := plain[i+1:]
+			password = strings.TrimSpace(password)
+			return username, password
+		}
+
+		logrus.Error("Malformatted authentication string; format must be <username>:<password>")
+		return "", ""
+	}
+
+	stdin := bufio.NewReader(os.Stdin)
+	input := make(chan string, 1)
+	fmt.Fprintf(os.Stdout, "Enter username: ")
+	go getUsername(input)
+	var username string
+	select {
+	case i := <-input:
+		username = strings.TrimSpace(i)
+		if username == "" {
+			return "", ""
+		}
+	case <-time.After(30 * time.Second):
+		logrus.Error("timeout when retrieving username input")
+		return "", ""
+	}
+
+	fmt.Fprintf(os.Stdout, "Enter password: ")
+	passphrase, err := passphrase.GetPassphrase(stdin)
+	fmt.Fprintln(os.Stdout)
+	if err != nil {
+		logrus.Errorf("error processing password input: %s", err)
+		return "", ""
+	}
+	password := strings.TrimSpace(string(passphrase))
+
+	return username, password
+}
+
+// to comply with the CredentialStore interface
+func (ps passwordStore) RefreshToken(u *url.URL, service string) string {
+	return ""
+}
+
+// to comply with the CredentialStore interface
+func (ps passwordStore) SetRefreshToken(u *url.URL, service string, token string) {
+}
+
+type httpAccess int
+
+const (
+	readOnly httpAccess = iota
+	readWrite
+	admin
+)
+
+// It correctly handles the auth challenge/credentials required to interact
+// with a notary server over both HTTP Basic Auth and the JWT auth implemented
+// in the notary-server
+// The readOnly flag indicates if the operation should be performed as an
+// anonymous read only operation. If the command entered requires write
+// permissions on the server, readOnly must be false
+func getTransport(config *viper.Viper, gun data.GUN, permission httpAccess) (http.RoundTripper, error) {
+	// Attempt to get a root CA from the config file. Nil is the host defaults.
+	rootCAFile := utils.GetPathRelativeToConfig(config, "remote_server.root_ca")
+	clientCert := utils.GetPathRelativeToConfig(config, "remote_server.tls_client_cert")
+	clientKey := utils.GetPathRelativeToConfig(config, "remote_server.tls_client_key")
+
+	insecureSkipVerify := false
+	if config.IsSet("remote_server.skipTLSVerify") {
+		insecureSkipVerify = config.GetBool("remote_server.skipTLSVerify")
+	}
+
+	if clientCert == "" && clientKey != "" || clientCert != "" && clientKey == "" {
+		return nil, fmt.Errorf("either pass both client key and cert, or neither")
+	}
+
+	tlsConfig, err := tlsconfig.Client(tlsconfig.Options{
+		CAFile:             rootCAFile,
+		InsecureSkipVerify: insecureSkipVerify,
+		CertFile:           clientCert,
+		KeyFile:            clientKey,
+		ExclusiveRootPools: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to configure TLS: %s", err.Error())
+	}
+
+	base := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).Dial,
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     tlsConfig,
+		DisableKeepAlives:   true,
+	}
+	trustServerURL := getRemoteTrustServer(config)
+	return tokenAuth(trustServerURL, base, gun, permission)
+}
+
+func tokenAuth(trustServerURL string, baseTransport *http.Transport, gun data.GUN,
+	permission httpAccess) (http.RoundTripper, error) {
+
+	// TODO(dmcgowan): add notary specific headers
+	authTransport := transport.NewTransport(baseTransport)
+	pingClient := &http.Client{
+		Transport: authTransport,
+		Timeout:   5 * time.Second,
+	}
+	endpoint, err := url.Parse(trustServerURL)
+	if err != nil {
+		return nil, fmt.Errorf("Could not parse remote trust server url (%s): %s", trustServerURL, err.Error())
+	}
+	if endpoint.Scheme == "" {
+		return nil, fmt.Errorf("Trust server url has to be in the form of http(s)://URL:PORT. Got: %s", trustServerURL)
+	}
+	subPath, err := url.Parse(path.Join(endpoint.Path, "/v2") + "/")
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse v2 subpath. This error should not have been reached. Please report it as an issue at https://github.com/theupdateframework/notary/issues: %s", err.Error())
+	}
+	endpoint = endpoint.ResolveReference(subPath)
+	req, err := http.NewRequest("GET", endpoint.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := pingClient.Do(req)
+	if err != nil {
+		logrus.Errorf("could not reach %s: %s", trustServerURL, err.Error())
+		logrus.Info("continuing in offline mode")
+		return nil, nil
+	}
+	// non-nil err means we must close body
+	defer resp.Body.Close()
+	if (resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices) &&
+		resp.StatusCode != http.StatusUnauthorized {
+		// If we didn't get a 2XX range or 401 status code, we're not talking to a notary server.
+		// The http client should be configured to handle redirects so at this point, 3XX is
+		// not a valid status code.
+		logrus.Errorf("could not reach %s: %d", trustServerURL, resp.StatusCode)
+		logrus.Info("continuing in offline mode")
+		return nil, nil
+	}
+
+	challengeManager := challenge.NewSimpleManager()
+	if err := challengeManager.AddResponse(resp); err != nil {
+		return nil, err
+	}
+
+	ps := passwordStore{anonymous: permission == readOnly}
+
+	var actions []string
+	switch permission {
+	case admin:
+		actions = []string{"*"}
+	case readWrite:
+		actions = []string{"push", "pull"}
+	case readOnly:
+		actions = []string{"pull"}
+	default:
+		return nil, fmt.Errorf("Invalid permission requested for token authentication of gun %s", gun)
+	}
+
+	tokenHandler := auth.NewTokenHandler(authTransport, ps, gun.String(), actions...)
+	basicHandler := auth.NewBasicHandler(ps)
+
+	modifier := auth.NewAuthorizer(challengeManager, tokenHandler, basicHandler)
+
+	if permission != readOnly {
+		return newAuthRoundTripper(transport.NewTransport(baseTransport, modifier)), nil
+	}
+
+	// Try to authenticate read only repositories using basic username/password authentication
+	return newAuthRoundTripper(transport.NewTransport(baseTransport, modifier),
+		transport.NewTransport(baseTransport, auth.NewAuthorizer(challengeManager, auth.NewTokenHandler(authTransport, passwordStore{anonymous: false}, gun.String(), actions...)))), nil
+}
+
+func getRemoteTrustServer(config *viper.Viper) string {
+	if configRemote := config.GetString("remote_server.url"); configRemote != "" {
+		return configRemote
+	}
+	return defaultServerURL
+}
+
+func getTrustPinning(config *viper.Viper) (trustpinning.TrustPinConfig, error) {
+	var ok bool
+	// Need to parse out Certs section from config
+	certMap := config.GetStringMap("trust_pinning.certs")
+	resultCertMap := make(map[string][]string)
+	for gun, certSlice := range certMap {
+		var castedCertSlice []interface{}
+		if castedCertSlice, ok = certSlice.([]interface{}); !ok {
+			return trustpinning.TrustPinConfig{}, fmt.Errorf("invalid format for trust_pinning.certs")
+		}
+		certsForGun := make([]string, len(castedCertSlice))
+		for idx, certIDInterface := range castedCertSlice {
+			if certID, ok := certIDInterface.(string); ok {
+				certsForGun[idx] = certID
+			} else {
+				return trustpinning.TrustPinConfig{}, fmt.Errorf("invalid format for trust_pinning.certs")
+			}
+		}
+		resultCertMap[gun] = certsForGun
+	}
+	return trustpinning.TrustPinConfig{
+		DisableTOFU: config.GetBool("trust_pinning.disable_tofu"),
+		CA:          config.GetStringMapString("trust_pinning.ca"),
+		Certs:       resultCertMap,
+	}, nil
+}
+
+// authRoundTripper tries to authenticate the requests via multiple HTTP transactions (until first succeed)
+type authRoundTripper struct {
+	trippers []http.RoundTripper
+}
+
+func newAuthRoundTripper(trippers ...http.RoundTripper) http.RoundTripper {
+	return &authRoundTripper{trippers: trippers}
+}
+
+func (a *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+
+	var resp *http.Response
+	// Try all run all transactions
+	for _, t := range a.trippers {
+		var err error
+		resp, err = t.RoundTrip(req)
+		// Reject on error
+		if err != nil {
+			return resp, err
+		}
+
+		// Stop when request is authorized/unknown error
+		if resp.StatusCode != http.StatusUnauthorized {
+			return resp, nil
+		}
+	}
+
+	// Return the last response
+	return resp, nil
+}

--- a/cmd/diff/diff.go
+++ b/cmd/diff/diff.go
@@ -4,33 +4,31 @@ import (
 	"bufio"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
-	"fmt"
-	"time"
 	"path"
+	"strings"
+	"time"
 
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/auth/challenge"
 	"github.com/docker/distribution/registry/client/transport"
+	"github.com/docker/go-connections/tlsconfig"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/docker/go-connections/tlsconfig"
 
-	"github.com/theupdateframework/notary/tuf/data"
+	"github.com/theupdateframework/notary/client"
 	"github.com/theupdateframework/notary/passphrase"
 	"github.com/theupdateframework/notary/trustpinning"
+	"github.com/theupdateframework/notary/tuf/data"
 	"github.com/theupdateframework/notary/utils"
-	"github.com/theupdateframework/notary/client"
 )
 
 func (n *notaryCommander) Diff(cmd *cobra.Command, args []string) {
-	cmd.Println("Running diff on", "gun")
-
 	if len(args) < 3 {
 		cmd.Usage()
 		logrus.Fatalf("Must specify a GUN and two timestamp hashes")
@@ -58,9 +56,8 @@ func (n *notaryCommander) Diff(cmd *cobra.Command, args []string) {
 	if err != nil {
 		logrus.Fatalf(err.Error())
 	}
-	cmd.Println(out)
+	cmd.Println(string(out))
 }
-
 
 type passwordStore struct {
 	anonymous bool

--- a/cmd/diff/integration_nonpkcs11_test.go
+++ b/cmd/diff/integration_nonpkcs11_test.go
@@ -1,0 +1,30 @@
+// +build !pkcs11
+
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/theupdateframework/notary"
+	"github.com/theupdateframework/notary/passphrase"
+)
+
+func init() {
+	NewNotaryCommand = func() *cobra.Command {
+		commander := &notaryCommander{
+			getRetriever: func() notary.PassRetriever { return passphrase.ConstantRetriever(testPassphrase) },
+		}
+		return commander.GetCommand()
+	}
+}
+
+func rootOnHardware() bool {
+	return false
+}
+
+// Per-test set up that is a no-op
+func setUp(t *testing.T) {}
+
+// no-op
+func verifyRootKeyOnHardware(t *testing.T, rootKeyID string) {}

--- a/cmd/diff/main.go
+++ b/cmd/diff/main.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/theupdateframework/notary"
+	"github.com/theupdateframework/notary/passphrase"
+)
+
+const (
+	configDir        = ".notary/"
+	defaultServerURL = "https://notary-server:4443"
+)
+
+type usageTemplate struct {
+	Use   string
+	Short string
+	Long  string
+}
+
+type cobraRunE func(cmd *cobra.Command, args []string) error
+
+func (u usageTemplate) ToCommand(run cobraRunE) *cobra.Command {
+	c := cobra.Command{
+		Use:   u.Use,
+		Short: u.Short,
+		Long:  u.Long,
+	}
+	if run != nil {
+		// newer versions of cobra support a run function that returns an error,
+		// but in the meantime, this should help ease the transition
+		c.RunE = run
+	}
+	return &c
+}
+
+func pathRelativeToCwd(path string) string {
+	if path == "" || filepath.IsAbs(path) {
+		return path
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	return filepath.Clean(filepath.Join(cwd, path))
+}
+
+type notaryCommander struct {
+	// this needs to be set
+	getRetriever func() notary.PassRetriever
+
+	// these are for command line parsing - no need to set
+	debug             bool
+	verbose           bool
+	trustDir          string
+	configFile        string
+	remoteTrustServer string
+
+	tlsCAFile   string
+	tlsCertFile string
+	tlsKeyFile  string
+}
+
+func (n *notaryCommander) parseConfig() (*viper.Viper, error) {
+	n.setVerbosityLevel()
+
+	// Get home directory for current user
+	homeDir, err := homedir.Dir()
+	if err != nil {
+		return nil, fmt.Errorf("cannot get current user home directory: %v", err)
+	}
+	if homeDir == "" {
+		return nil, fmt.Errorf("cannot get current user home directory")
+	}
+
+	config := viper.New()
+
+	// By default our trust directory (where keys are stored) is in ~/.notary/
+	defaultTrustDir := filepath.Join(homeDir, filepath.Dir(configDir))
+
+	// If there was a commandline configFile set, we parse that.
+	// If there wasn't we attempt to find it on the default location ~/.notary/config.json
+	if n.configFile != "" {
+		config.SetConfigFile(n.configFile)
+	} else {
+		config.SetConfigFile(filepath.Join(defaultTrustDir, "config.json"))
+	}
+
+	// Setup the configuration details into viper
+	config.SetDefault("trust_dir", defaultTrustDir)
+	config.SetDefault("remote_server", map[string]string{"url": defaultServerURL})
+
+	// Find and read the config file
+	if err := config.ReadInConfig(); err != nil {
+		logrus.Debugf("Configuration file not found, using defaults")
+
+		// If we were passed in a configFile via command linen flags, bail if it doesn't exist,
+		// otherwise ignore it: we can use the defaults
+		if n.configFile != "" || !os.IsNotExist(err) {
+			return nil, fmt.Errorf("error opening config file: %v", err)
+		}
+	}
+
+	// At this point we either have the default value or the one set by the config.
+	// Either way, some command-line flags have precedence and overwrites the value
+	if n.trustDir != "" {
+		config.Set("trust_dir", pathRelativeToCwd(n.trustDir))
+	}
+	if n.tlsCAFile != "" {
+		config.Set("remote_server.root_ca", pathRelativeToCwd(n.tlsCAFile))
+	}
+	if n.tlsCertFile != "" {
+		config.Set("remote_server.tls_client_cert", pathRelativeToCwd(n.tlsCertFile))
+	}
+	if n.tlsKeyFile != "" {
+		config.Set("remote_server.tls_client_key", pathRelativeToCwd(n.tlsKeyFile))
+	}
+	if n.remoteTrustServer != "" {
+		config.Set("remote_server.url", n.remoteTrustServer)
+	}
+
+	// Expands all the possible ~/ that have been given, either through -d or config
+	// If there is no error, use it, if not, just attempt to use whatever the user gave us
+	expandedTrustDir, err := homedir.Expand(config.GetString("trust_dir"))
+	if err == nil {
+		config.Set("trust_dir", expandedTrustDir)
+	}
+	logrus.Debugf("Using the following trust directory: %s", config.GetString("trust_dir"))
+
+	return config, nil
+}
+
+func (n *notaryCommander) GetCommand() *cobra.Command {
+	notaryCmd := cobra.Command{
+		Use:           "notarydiff",
+		Short:         "notarydiff prints the difference between two versions of a notary repo.",
+		Long:          "notarydiff prints the difference in two versions of the same notary repo. Versions are specific by the hashes of their timestamps which can be found by using the changefeed.",
+		Run:           n.Diff,
+	}
+	notaryCmd.SetOutput(os.Stdout)
+
+	notaryCmd.PersistentFlags().StringVarP(
+		&n.trustDir, "trustDir", "d", "", "Directory where the trust data is persisted to")
+	notaryCmd.PersistentFlags().StringVarP(
+		&n.configFile, "configFile", "c", "", "Path to the configuration file to use")
+	notaryCmd.PersistentFlags().BoolVarP(&n.verbose, "verbose", "v", false, "Verbose output")
+	notaryCmd.PersistentFlags().BoolVarP(&n.debug, "debug", "D", false, "Debug output")
+	notaryCmd.PersistentFlags().StringVarP(&n.remoteTrustServer, "server", "s", "", "Remote trust server location")
+	notaryCmd.PersistentFlags().StringVar(&n.tlsCAFile, "tlscacert", "", "Trust certs signed only by this CA")
+	notaryCmd.PersistentFlags().StringVar(&n.tlsCertFile, "tlscert", "", "Path to TLS certificate file")
+	notaryCmd.PersistentFlags().StringVar(&n.tlsKeyFile, "tlskey", "", "Path to TLS key file")
+
+	return &notaryCmd
+}
+
+func main() {
+	notaryCommander := &notaryCommander{getRetriever: getPassphraseRetriever}
+	notaryCmd := notaryCommander.GetCommand()
+	if err := notaryCmd.Execute(); err != nil {
+		notaryCmd.Println("")
+		fatalf(err.Error())
+	}
+}
+
+func fatalf(format string, args ...interface{}) {
+	fmt.Printf("* fatal: "+format+"\n", args...)
+	os.Exit(1)
+}
+
+func askConfirm(input io.Reader) bool {
+	var res string
+	if _, err := fmt.Fscanln(input, &res); err != nil {
+		return false
+	}
+	if strings.EqualFold(res, "y") || strings.EqualFold(res, "yes") {
+		return true
+	}
+	return false
+}
+
+func getPassphraseRetriever() notary.PassRetriever {
+	return passphrase.PromptRetriever()
+}
+
+// Set the logging level to warn on default, or the most verbose level the user specified (debug, info)
+func (n *notaryCommander) setVerbosityLevel() {
+	if n.debug {
+		logrus.SetLevel(logrus.DebugLevel)
+	} else if n.verbose {
+		logrus.SetLevel(logrus.InfoLevel)
+	} else {
+		logrus.SetLevel(logrus.WarnLevel)
+	}
+	logrus.SetOutput(os.Stderr)
+}

--- a/cmd/diff/main_test.go
+++ b/cmd/diff/main_test.go
@@ -1,0 +1,645 @@
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/docker/go-connections/tlsconfig"
+	"github.com/stretchr/testify/require"
+	"github.com/theupdateframework/notary"
+	"github.com/theupdateframework/notary/passphrase"
+	"github.com/theupdateframework/notary/server/storage"
+	"github.com/theupdateframework/notary/tuf/data"
+)
+
+// the default location for the config file is in ~/.notary/config.json - even if it doesn't exist.
+func TestNotaryConfigFileDefault(t *testing.T) {
+	commander := &notaryCommander{
+		getRetriever: func() notary.PassRetriever { return passphrase.ConstantRetriever("pass") },
+	}
+
+	config, err := commander.parseConfig()
+	require.NoError(t, err)
+	configFileUsed := config.ConfigFileUsed()
+	require.True(t, strings.HasSuffix(configFileUsed,
+		filepath.Join(".notary", "config.json")), "Unknown config file: %s", configFileUsed)
+}
+
+// the default server address is notary-server
+func TestRemoteServerDefault(t *testing.T) {
+	tempDir := tempDirWithConfig(t, "{}")
+	defer os.RemoveAll(tempDir)
+	configFile := filepath.Join(tempDir, "config.json")
+
+	commander := &notaryCommander{
+		getRetriever: func() notary.PassRetriever { return passphrase.ConstantRetriever("pass") },
+	}
+
+	// set a blank config file, so it doesn't check ~/.notary/config.json by default
+	// and execute a random command so that the flags are parsed
+	cmd := commander.GetCommand()
+	cmd.SetArgs([]string{"-c", configFile, "list"})
+	cmd.SetOutput(new(bytes.Buffer)) // eat the output
+	cmd.Execute()
+
+	config, err := commander.parseConfig()
+	require.NoError(t, err)
+	require.Equal(t, "https://notary-server:4443", getRemoteTrustServer(config))
+}
+
+// providing a config file uses the config file's server url instead
+func TestRemoteServerUsesConfigFile(t *testing.T) {
+	tempDir := tempDirWithConfig(t, `{"remote_server": {"url": "https://myserver"}}`)
+	defer os.RemoveAll(tempDir)
+	configFile := filepath.Join(tempDir, "config.json")
+
+	commander := &notaryCommander{
+		getRetriever: func() notary.PassRetriever { return passphrase.ConstantRetriever("pass") },
+	}
+
+	// set a config file, so it doesn't check ~/.notary/config.json by default,
+	// and execute a random command so that the flags are parsed
+	cmd := commander.GetCommand()
+	cmd.SetArgs([]string{"-c", configFile, "list"})
+	cmd.SetOutput(new(bytes.Buffer)) // eat the output
+	cmd.Execute()
+
+	config, err := commander.parseConfig()
+	require.NoError(t, err)
+	require.Equal(t, "https://myserver", getRemoteTrustServer(config))
+}
+
+// a command line flag overrides the config file's server url
+func TestRemoteServerCommandLineFlagOverridesConfig(t *testing.T) {
+	tempDir := tempDirWithConfig(t, `{"remote_server": {"url": "https://myserver"}}`)
+	defer os.RemoveAll(tempDir)
+	configFile := filepath.Join(tempDir, "config.json")
+
+	commander := &notaryCommander{
+		getRetriever: func() notary.PassRetriever { return passphrase.ConstantRetriever("pass") },
+	}
+
+	// set a config file, so it doesn't check ~/.notary/config.json by default,
+	// and execute a random command so that the flags are parsed
+	cmd := commander.GetCommand()
+	cmd.SetArgs([]string{"-c", configFile, "-s", "http://overridden", "list"})
+	cmd.SetOutput(new(bytes.Buffer)) // eat the output
+	cmd.Execute()
+
+	config, err := commander.parseConfig()
+	require.NoError(t, err)
+	require.Equal(t, "http://overridden", getRemoteTrustServer(config))
+}
+
+// invalid commands for `notary addhash`
+func TestInvalidAddHashCommands(t *testing.T) {
+	tempDir := tempDirWithConfig(t, `{"remote_server": {"url": "https://myserver"}}`)
+	defer os.RemoveAll(tempDir)
+	configFile := filepath.Join(tempDir, "config.json")
+
+	b := new(bytes.Buffer)
+	cmd := NewNotaryCommand()
+	cmd.SetOutput(b)
+
+	// No hashes given
+	cmd.SetArgs(append([]string{"-c", configFile, "-d", tempDir}, "addhash", "gun", "test", "10"))
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Must specify a GUN, target, byte size of target data, and at least one hash")
+
+	// Invalid byte size given
+	cmd = NewNotaryCommand()
+	cmd.SetArgs(append([]string{"-c", configFile, "-d", tempDir}, "addhash", "gun", "test", "sizeNotAnInt", "--sha256", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+	err = cmd.Execute()
+	require.Error(t, err)
+
+	// Invalid sha256 size given
+	cmd = NewNotaryCommand()
+	cmd.SetArgs(append([]string{"-c", configFile, "-d", tempDir}, "addhash", "gun", "test", "1", "--sha256", "a"))
+	err = cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid sha256 hex contents provided")
+
+	// Invalid sha256 hex given
+	cmd = NewNotaryCommand()
+	cmd.SetArgs(append([]string{"-c", configFile, "-d", tempDir}, "addhash", "gun", "test", "1", "--sha256", "***aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa***"))
+	err = cmd.Execute()
+	require.Error(t, err)
+
+	// Invalid sha512 size given
+	cmd = NewNotaryCommand()
+	cmd.SetArgs(append([]string{"-c", configFile, "-d", tempDir}, "addhash", "gun", "test", "1", "--sha512", "a"))
+	err = cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid sha512 hex contents provided")
+
+	// Invalid sha512 hex given
+	cmd = NewNotaryCommand()
+	cmd.SetArgs(append([]string{"-c", configFile, "-d", tempDir}, "addhash", "gun", "test", "1", "--sha512", "***aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa******aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa***"))
+	err = cmd.Execute()
+	require.Error(t, err)
+}
+
+var exampleValidCommands = []string{
+	"init repo",
+	"list repo",
+	"status repo",
+	"reset repo --all",
+	"publish repo",
+	"add repo v1 somefile",
+	"addhash repo targetv1 --sha256 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 10",
+	"verify repo v1",
+	"key list",
+	"key rotate repo snapshot",
+	"key generate ecdsa",
+	"key remove e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+	"key passwd e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+	"key import backup.pem",
+	"delegation list repo",
+	"delegation add repo targets/releases path/to/pem/file.pem",
+	"delegation remove repo targets/releases",
+	"witness gun targets/releases",
+	"delete repo",
+}
+
+// config parsing bugs are propagated in all commands
+func TestConfigParsingErrorsPropagatedByCommands(t *testing.T) {
+	tempdir, err := ioutil.TempDir("", "empty-dir")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempdir)
+
+	for _, args := range exampleValidCommands {
+		b := new(bytes.Buffer)
+		cmd := NewNotaryCommand()
+		cmd.SetOutput(b)
+
+		cmd.SetArgs(append(
+			[]string{"-c", filepath.Join(tempdir, "idonotexist.json"), "-d", tempdir},
+			strings.Fields(args)...))
+		err = cmd.Execute()
+
+		require.Error(t, err, "expected error when running `notary %s`", args)
+		require.Contains(t, err.Error(), "error opening config file", "running `notary %s`", args)
+		require.NotContains(t, b.String(), "Usage:")
+	}
+}
+
+// insufficient arguments produce an error before any parsing of configs happens
+func TestInsufficientArgumentsReturnsErrorAndPrintsUsage(t *testing.T) {
+	tempdir, err := ioutil.TempDir("", "empty-dir")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempdir)
+
+	for _, args := range exampleValidCommands {
+		b := new(bytes.Buffer)
+		cmd := NewNotaryCommand()
+		cmd.SetOutput(b)
+
+		arglist := strings.Fields(args)
+		if args == "key list" || args == "key generate ecdsa" {
+			// in these case, "key" or "key generate" are valid commands, so add an arg to them instead
+			arglist = append(arglist, "extraArg")
+		} else {
+			arglist = arglist[:len(arglist)-1]
+		}
+
+		invalid := strings.Join(arglist, " ")
+
+		cmd.SetArgs(append(
+			[]string{"-c", filepath.Join(tempdir, "idonotexist.json"), "-d", tempdir}, arglist...))
+		err = cmd.Execute()
+
+		require.NotContains(t, err.Error(), "error opening config file", "running `notary %s`", invalid)
+		// it's a usage error, so the usage is printed
+		require.Contains(t, b.String(), "Usage:", "expected usage when running `notary %s`", invalid)
+	}
+}
+
+// The bare notary command and bare subcommands all print out usage
+func TestBareCommandPrintsUsageAndNoError(t *testing.T) {
+	tempdir, err := ioutil.TempDir("", "empty-dir")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempdir)
+
+	// just the notary command
+	b := new(bytes.Buffer)
+	cmd := NewNotaryCommand()
+	cmd.SetOutput(b)
+
+	cmd.SetArgs([]string{"-c", filepath.Join(tempdir, "idonotexist.json")})
+	require.NoError(t, cmd.Execute(), "Expected no error from a help request")
+	// usage is printed
+	require.Contains(t, b.String(), "Usage:", "expected usage when running `notary`")
+
+	// notary key and notary delegation
+	for _, bareCommand := range []string{"key", "delegation"} {
+		b := new(bytes.Buffer)
+		cmd := NewNotaryCommand()
+		cmd.SetOutput(b)
+
+		cmd.SetArgs([]string{"-c", filepath.Join(tempdir, "idonotexist.json"), "-d", tempdir, bareCommand})
+		require.NoError(t, cmd.Execute(), "Expected no error from a help request")
+		// usage is printed
+		require.Contains(t, b.String(), "Usage:", "expected usage when running `notary %s`", bareCommand)
+	}
+}
+
+type recordingMetaStore struct {
+	gotten []string
+	storage.MemStorage
+}
+
+// GetCurrent gets the metadata from the underlying MetaStore, but also records
+// that the metadata was requested
+func (r *recordingMetaStore) GetCurrent(gun data.GUN, role data.RoleName) (*time.Time, []byte, error) {
+	r.gotten = append(r.gotten, fmt.Sprintf("%s.%s", gun.String(), role.String()))
+	return r.MemStorage.GetCurrent(gun, role)
+}
+
+// GetChecksum gets the metadata from the underlying MetaStore, but also records
+// that the metadata was requested
+func (r *recordingMetaStore) GetChecksum(gun data.GUN, role data.RoleName, checksum string) (*time.Time, []byte, error) {
+	r.gotten = append(r.gotten, fmt.Sprintf("%s.%s", gun.String(), role.String()))
+	return r.MemStorage.GetChecksum(gun, role, checksum)
+}
+
+// the config can provide all the TLS information necessary - the root ca file,
+// the tls client files - they are all relative to the directory of the config
+// file, and not the cwd
+func TestConfigFileTLSCannotBeRelativeToCWD(t *testing.T) {
+	// Set up server that with a self signed cert
+	var err error
+	// add a handler for getting the root
+	m := &recordingMetaStore{MemStorage: *storage.NewMemStorage()}
+	s := httptest.NewUnstartedServer(setupServerHandler(m))
+	s.TLS, err = tlsconfig.Server(tlsconfig.Options{
+		CertFile:           "../../fixtures/notary-server.crt",
+		KeyFile:            "../../fixtures/notary-server.key",
+		CAFile:             "../../fixtures/root-ca.crt",
+		ClientAuth:         tls.RequireAndVerifyClientCert,
+		ExclusiveRootPools: true,
+	})
+	require.NoError(t, err)
+	s.StartTLS()
+	defer s.Close()
+
+	// test that a config file with certs that are relative to the cwd fail
+	tempDir := tempDirWithConfig(t, fmt.Sprintf(`{
+		"remote_server": {
+			"url": "%s",
+			"root_ca": "../../fixtures/root-ca.crt",
+			"tls_client_cert": "../../fixtures/notary-server.crt",
+			"tls_client_key": "../../fixtures/notary-server.key"
+		}
+	}`, s.URL))
+	defer os.RemoveAll(tempDir)
+	configFile := filepath.Join(tempDir, "config.json")
+
+	// set a config file, so it doesn't check ~/.notary/config.json by default,
+	// and execute a random command so that the flags are parsed
+	cmd := NewNotaryCommand()
+	cmd.SetArgs([]string{"-c", configFile, "-d", tempDir, "list", "repo"})
+	cmd.SetOutput(new(bytes.Buffer)) // eat the output
+	err = cmd.Execute()
+	require.Error(t, err, "expected a failure due to TLS")
+	require.Contains(t, err.Error(), "TLS", "should have been a TLS error")
+
+	// validate that we failed to connect and attempt any downloads at all
+	require.Len(t, m.gotten, 0)
+}
+
+// the config can provide all the TLS information necessary - the root ca file,
+// the tls client files - they are all relative to the directory of the config
+// file, and not the cwd, or absolute paths
+func TestConfigFileTLSCanBeRelativeToConfigOrAbsolute(t *testing.T) {
+	// Set up server that with a self signed cert
+	var err error
+	// add a handler for getting the root
+	m := &recordingMetaStore{MemStorage: *storage.NewMemStorage()}
+	s := httptest.NewUnstartedServer(setupServerHandler(m))
+	s.TLS, err = tlsconfig.Server(tlsconfig.Options{
+		CertFile:           "../../fixtures/notary-server.crt",
+		KeyFile:            "../../fixtures/notary-server.key",
+		CAFile:             "../../fixtures/root-ca.crt",
+		ClientAuth:         tls.RequireAndVerifyClientCert,
+		ExclusiveRootPools: true,
+	})
+	require.NoError(t, err)
+	s.StartTLS()
+	defer s.Close()
+
+	tempDir, err := ioutil.TempDir("", "config-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+	configFile, err := os.Create(filepath.Join(tempDir, "config.json"))
+	require.NoError(t, err)
+	fmt.Fprintf(configFile, `{
+		"remote_server": {
+			"url": "%s",
+			"root_ca": "root-ca.crt",
+			"tls_client_cert": %s,
+			"tls_client_key": "notary-server.key"
+		}
+	}`, s.URL, strconv.Quote(filepath.Join(tempDir, "notary-server.crt")))
+	configFile.Close()
+
+	// copy the certs to be relative to the config directory
+	for _, fname := range []string{"notary-server.crt", "notary-server.key", "root-ca.crt"} {
+		content, err := ioutil.ReadFile(filepath.Join("../../fixtures", fname))
+		require.NoError(t, err)
+		require.NoError(t, ioutil.WriteFile(filepath.Join(tempDir, fname), content, 0766))
+	}
+
+	// set a config file, so it doesn't check ~/.notary/config.json by default,
+	// and execute a random command so that the flags are parsed
+	cmd := NewNotaryCommand()
+	cmd.SetArgs([]string{"-c", configFile.Name(), "-d", tempDir, "list", "repo"})
+	cmd.SetOutput(new(bytes.Buffer)) // eat the output
+	err = cmd.Execute()
+	require.Error(t, err, "there was no repository, so list should have failed")
+	require.NotContains(t, err.Error(), "TLS", "there was no TLS error though!")
+
+	// validate that we actually managed to connect and attempted to download the root though
+	require.Len(t, m.gotten, 1)
+	require.Equal(t, m.gotten[0], "repo.root")
+}
+
+// Whatever TLS config is in the config file can be overridden by the command line
+// TLS flags, which are relative to the CWD (not the config) or absolute
+func TestConfigFileOverridenByCmdLineFlags(t *testing.T) {
+	// Set up server that with a self signed cert
+	var err error
+	// add a handler for getting the root
+	m := &recordingMetaStore{MemStorage: *storage.NewMemStorage()}
+	s := httptest.NewUnstartedServer(setupServerHandler(m))
+	s.TLS, err = tlsconfig.Server(tlsconfig.Options{
+		CertFile:           "../../fixtures/notary-server.crt",
+		KeyFile:            "../../fixtures/notary-server.key",
+		CAFile:             "../../fixtures/root-ca.crt",
+		ClientAuth:         tls.RequireAndVerifyClientCert,
+		ExclusiveRootPools: true,
+	})
+	require.NoError(t, err)
+	s.StartTLS()
+	defer s.Close()
+
+	tempDir := tempDirWithConfig(t, fmt.Sprintf(`{
+		"remote_server": {
+			"url": "%s",
+			"root_ca": "nope",
+			"tls_client_cert": "nope",
+			"tls_client_key": "nope"
+		}
+	}`, s.URL))
+	defer os.RemoveAll(tempDir)
+	configFile := filepath.Join(tempDir, "config.json")
+
+	// set a config file, so it doesn't check ~/.notary/config.json by default,
+	// and execute a random command so that the flags are parsed
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	cmd := NewNotaryCommand()
+	cmd.SetArgs([]string{
+		"-c", configFile, "-d", tempDir, "list", "repo",
+		"--tlscacert", "../../fixtures/root-ca.crt",
+		"--tlscert", filepath.Clean(filepath.Join(cwd, "../../fixtures/notary-server.crt")),
+		"--tlskey", "../../fixtures/notary-server.key"})
+	cmd.SetOutput(new(bytes.Buffer)) // eat the output
+	err = cmd.Execute()
+	require.Error(t, err, "there was no repository, so list should have failed")
+	require.NotContains(t, err.Error(), "TLS", "there was no TLS error though!")
+
+	// validate that we actually managed to connect and attempted to download the root though
+	require.Len(t, m.gotten, 1)
+	require.Equal(t, m.gotten[0], "repo.root")
+}
+
+// the config can specify trust pinning settings for TOFUs, as well as pinned Certs or CA
+func TestConfigFileTrustPinning(t *testing.T) {
+	var err error
+
+	tempDir := tempDirWithConfig(t, `{
+        "trust_pinning": {
+            "disable_tofu": false
+         }
+	}`)
+	defer os.RemoveAll(tempDir)
+	commander := &notaryCommander{
+		getRetriever: func() notary.PassRetriever { return passphrase.ConstantRetriever("pass") },
+		configFile:   filepath.Join(tempDir, "config.json"),
+	}
+
+	// Check that tofu was set correctly
+	config, err := commander.parseConfig()
+	require.NoError(t, err)
+	require.Equal(t, false, config.GetBool("trust_pinning.disable_tofu"))
+	trustPin, err := getTrustPinning(config)
+	require.NoError(t, err)
+	require.Equal(t, false, trustPin.DisableTOFU)
+
+	tempDir = tempDirWithConfig(t, `{
+		"remote_server": {
+			"url": "%s"
+		},
+		"trust_pinning": {
+		    "disable_tofu": true
+		}
+	}`)
+	defer os.RemoveAll(tempDir)
+	commander = &notaryCommander{
+		getRetriever: func() notary.PassRetriever { return passphrase.ConstantRetriever("pass") },
+		configFile:   filepath.Join(tempDir, "config.json"),
+	}
+
+	// Check that tofu was correctly disabled
+	config, err = commander.parseConfig()
+	require.NoError(t, err)
+	require.Equal(t, true, config.GetBool("trust_pinning.disable_tofu"))
+	trustPin, err = getTrustPinning(config)
+	require.NoError(t, err)
+	require.Equal(t, true, trustPin.DisableTOFU)
+
+	tempDir = tempDirWithConfig(t, fmt.Sprintf(`{
+		"trust_pinning": {
+		    "certs": {
+		        "repo3": ["%s"]
+		    }
+		 }
+	}`, strings.Repeat("x", notary.SHA256HexSize)))
+	defer os.RemoveAll(tempDir)
+	commander = &notaryCommander{
+		getRetriever: func() notary.PassRetriever { return passphrase.ConstantRetriever("pass") },
+		configFile:   filepath.Join(tempDir, "config.json"),
+	}
+
+	config, err = commander.parseConfig()
+	require.NoError(t, err)
+	require.Equal(t, []interface{}{strings.Repeat("x", notary.SHA256HexSize)}, config.GetStringMap("trust_pinning.certs")["repo3"])
+	trustPin, err = getTrustPinning(config)
+	require.NoError(t, err)
+	require.Equal(t, strings.Repeat("x", notary.SHA256HexSize), trustPin.Certs["repo3"][0])
+
+	// Check that an invalid cert ID pinning format fails
+	tempDir = tempDirWithConfig(t, fmt.Sprintf(`{
+		"trust_pinning": {
+		    "certs": {
+		        "repo3": "%s"
+		    }
+		 }
+	}`, strings.Repeat("x", notary.SHA256HexSize)))
+	defer os.RemoveAll(tempDir)
+	commander = &notaryCommander{
+		getRetriever: func() notary.PassRetriever { return passphrase.ConstantRetriever("pass") },
+		configFile:   filepath.Join(tempDir, "config.json"),
+	}
+
+	config, err = commander.parseConfig()
+	require.NoError(t, err)
+	trustPin, err = getTrustPinning(config)
+	require.Error(t, err)
+
+	tempDir = tempDirWithConfig(t, fmt.Sprintf(`{
+		"trust_pinning": {
+		    "ca": {
+		        "repo4": "%s"
+		    }
+		 }
+	}`, "root-ca.crt"))
+	defer os.RemoveAll(tempDir)
+	commander = &notaryCommander{
+		getRetriever: func() notary.PassRetriever { return passphrase.ConstantRetriever("pass") },
+		configFile:   filepath.Join(tempDir, "config.json"),
+	}
+
+	config, err = commander.parseConfig()
+	require.NoError(t, err)
+	require.Equal(t, "root-ca.crt", config.GetStringMap("trust_pinning.ca")["repo4"])
+	trustPin, err = getTrustPinning(config)
+	require.NoError(t, err)
+	require.Equal(t, "root-ca.crt", trustPin.CA["repo4"])
+}
+
+// sets the env vars to empty, and returns a function to reset them at the end
+func cleanupAndSetEnvVars() func() {
+	orig := map[string]string{
+		"NOTARY_ROOT_PASSPHRASE":       "",
+		"NOTARY_TARGETS_PASSPHRASE":    "",
+		"NOTARY_SNAPSHOT_PASSPHRASE":   "",
+		"NOTARY_DELEGATION_PASSPHRASE": "",
+	}
+	for envVar := range orig {
+		orig[envVar] = os.Getenv(envVar)
+		os.Setenv(envVar, "")
+	}
+
+	return func() {
+		for envVar, value := range orig {
+			if value == "" {
+				os.Unsetenv(envVar)
+			} else {
+				os.Setenv(envVar, value)
+			}
+		}
+	}
+}
+
+func TestPassphraseRetrieverCaching(t *testing.T) {
+	defer cleanupAndSetEnvVars()()
+	// Only set up one passphrase environment var first for root
+	require.NoError(t, os.Setenv("NOTARY_ROOT_PASSPHRASE", "root_passphrase"))
+
+	// Check that root is cached
+	retriever := getPassphraseRetriever()
+	passphrase, giveup, err := retriever("key", data.CanonicalRootRole.String(), false, 0)
+	require.NoError(t, err)
+	require.False(t, giveup)
+	require.Equal(t, passphrase, "root_passphrase")
+
+	_, _, err = retriever("key", "user", false, 0)
+	require.Error(t, err)
+	_, _, err = retriever("key", data.CanonicalTargetsRole.String(), false, 0)
+	require.Error(t, err)
+	_, _, err = retriever("key", data.CanonicalSnapshotRole.String(), false, 0)
+	require.Error(t, err)
+	_, _, err = retriever("key", "targets/delegation", false, 0)
+	require.Error(t, err)
+
+	// Set up the rest of them
+	require.NoError(t, os.Setenv("NOTARY_TARGETS_PASSPHRASE", "targets_passphrase"))
+	require.NoError(t, os.Setenv("NOTARY_SNAPSHOT_PASSPHRASE", "snapshot_passphrase"))
+	require.NoError(t, os.Setenv("NOTARY_DELEGATION_PASSPHRASE", "delegation_passphrase"))
+
+	// Get a new retriever and check the caching
+	retriever = getPassphraseRetriever()
+	passphrase, giveup, err = retriever("key", data.CanonicalRootRole.String(), false, 0)
+	require.NoError(t, err)
+	require.False(t, giveup)
+	require.Equal(t, passphrase, "root_passphrase")
+
+	passphrase, giveup, err = retriever("key", data.CanonicalTargetsRole.String(), false, 0)
+	require.NoError(t, err)
+	require.False(t, giveup)
+	require.Equal(t, passphrase, "targets_passphrase")
+
+	passphrase, giveup, err = retriever("key", data.CanonicalSnapshotRole.String(), false, 0)
+	require.NoError(t, err)
+	require.False(t, giveup)
+	require.Equal(t, passphrase, "snapshot_passphrase")
+
+	passphrase, giveup, err = retriever("key", "targets/releases", false, 0)
+	require.NoError(t, err)
+	require.False(t, giveup)
+	require.Equal(t, passphrase, "delegation_passphrase")
+
+	// We don't require a targets/ prefix in PEM headers for delegation keys
+	passphrase, giveup, err = retriever("key", "user", false, 0)
+	require.NoError(t, err)
+	require.False(t, giveup)
+	require.Equal(t, passphrase, "delegation_passphrase")
+}
+
+func TestPassphraseRetrieverDelegationRoleCaching(t *testing.T) {
+	defer cleanupAndSetEnvVars()()
+	// Only set up one passphrase environment var first for delegations
+	require.NoError(t, os.Setenv("NOTARY_DELEGATION_PASSPHRASE", "delegation_passphrase"))
+
+	// Check that any delegation role is cached
+	retriever := getPassphraseRetriever()
+
+	passphrase, giveup, err := retriever("key", "targets/releases", false, 0)
+	require.NoError(t, err)
+	require.False(t, giveup)
+	require.Equal(t, passphrase, "delegation_passphrase")
+	passphrase, giveup, err = retriever("key", "targets/delegation", false, 0)
+	require.NoError(t, err)
+	require.False(t, giveup)
+	require.Equal(t, passphrase, "delegation_passphrase")
+	passphrase, giveup, err = retriever("key", "targets/a/b/c/d", false, 0)
+	require.NoError(t, err)
+	require.False(t, giveup)
+	require.Equal(t, passphrase, "delegation_passphrase")
+
+	// Also check arbitrary usernames that are non-BaseRoles or imported so that this can be shared across keys
+	passphrase, giveup, err = retriever("key", "user", false, 0)
+	require.NoError(t, err)
+	require.False(t, giveup)
+	require.Equal(t, passphrase, "delegation_passphrase")
+
+	// Make sure base roles fail
+	_, _, err = retriever("key", data.CanonicalRootRole.String(), false, 0)
+	require.Error(t, err)
+	_, _, err = retriever("key", data.CanonicalTargetsRole.String(), false, 0)
+	require.Error(t, err)
+	_, _, err = retriever("key", data.CanonicalSnapshotRole.String(), false, 0)
+	require.Error(t, err)
+}

--- a/cmd/diff/prettyprint.go
+++ b/cmd/diff/prettyprint.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/theupdateframework/notary/client"
+	"github.com/theupdateframework/notary/trustmanager"
+	"github.com/theupdateframework/notary/tuf/data"
+)
+
+const (
+	fourItemRow = "%s\t%s\t%s\t%s\n"
+	fiveItemRow = "%s\t%s\t%s\t%s\t%s\n"
+)
+
+func initTabWriter(columns []string, writer io.Writer) *tabwriter.Writer {
+	tw := tabwriter.NewWriter(writer, 4, 4, 4, ' ', 0)
+	fmt.Fprintln(tw, strings.Join(columns, "\t"))
+	breakLine := make([]string, 0, len(columns))
+	for _, h := range columns {
+		breakLine = append(
+			breakLine,
+			strings.Repeat("-", len(h)),
+		)
+	}
+	fmt.Fprintln(tw, strings.Join(breakLine, "\t"))
+	return tw
+}
+
+// --- pretty printing certs ---
+
+func truncateWithEllipsis(str string, maxWidth int, leftTruncate bool) string {
+	if len(str) <= maxWidth {
+		return str
+	}
+	if leftTruncate {
+		return fmt.Sprintf("...%s", str[len(str)-(maxWidth-3):])
+	}
+	return fmt.Sprintf("%s...", str[:maxWidth-3])
+}
+
+const (
+	maxGUNWidth = 25
+	maxLocWidth = 40
+)
+
+type keyInfo struct {
+	gun      data.GUN // assumption that this is "" if role is root
+	role     data.RoleName
+	keyID    string
+	location string
+}
+
+// We want to sort by gun, then by role, then by keyID, then by location
+// In the case of a root role, then there is no GUN, and a root role comes
+// first.
+type keyInfoSorter []keyInfo
+
+func (k keyInfoSorter) Len() int      { return len(k) }
+func (k keyInfoSorter) Swap(i, j int) { k[i], k[j] = k[j], k[i] }
+func (k keyInfoSorter) Less(i, j int) bool {
+	// special-case role
+	if k[i].role != k[j].role {
+		if k[i].role == data.CanonicalRootRole {
+			return true
+		}
+		if k[j].role == data.CanonicalRootRole {
+			return false
+		}
+		// otherwise, neither of them are root, they're just different, so
+		// go with the traditional sort order.
+	}
+
+	// sort order is GUN, role, keyID, location.
+	orderedI := []string{k[i].gun.String(), k[i].role.String(), k[i].keyID, k[i].location}
+	orderedJ := []string{k[j].gun.String(), k[j].role.String(), k[j].keyID, k[j].location}
+
+	for x := 0; x < 4; x++ {
+		switch {
+		case orderedI[x] < orderedJ[x]:
+			return true
+		case orderedI[x] > orderedJ[x]:
+			return false
+		}
+		// continue on and evalulate the next item
+	}
+	// this shouldn't happen - that means two values are exactly equal
+	return false
+}
+
+// Given a list of KeyStores in order of listing preference, pretty-prints the
+// root keys and then the signing keys.
+func prettyPrintKeys(keyStores []trustmanager.KeyStore, writer io.Writer) {
+	var info []keyInfo
+
+	for _, store := range keyStores {
+		for keyID, keyIDInfo := range store.ListKeys() {
+			info = append(info, keyInfo{
+				role:     keyIDInfo.Role,
+				location: store.Name(),
+				gun:      keyIDInfo.Gun,
+				keyID:    keyID,
+			})
+		}
+	}
+
+	if len(info) == 0 {
+		writer.Write([]byte("No signing keys found.\n"))
+		return
+	}
+
+	sort.Stable(keyInfoSorter(info))
+
+	tw := initTabWriter([]string{"ROLE", "GUN", "KEY ID", "LOCATION"}, writer)
+
+	for _, oneKeyInfo := range info {
+		fmt.Fprintf(
+			tw,
+			fourItemRow,
+			oneKeyInfo.role,
+			truncateWithEllipsis(oneKeyInfo.gun.String(), maxGUNWidth, true),
+			oneKeyInfo.keyID,
+			truncateWithEllipsis(oneKeyInfo.location, maxLocWidth, true),
+		)
+	}
+	tw.Flush()
+}
+
+// --- pretty printing targets ---
+
+type targetsSorter []*client.TargetWithRole
+
+func (t targetsSorter) Len() int      { return len(t) }
+func (t targetsSorter) Swap(i, j int) { t[i], t[j] = t[j], t[i] }
+func (t targetsSorter) Less(i, j int) bool {
+	return t[i].Name < t[j].Name
+}
+
+// --- pretty printing roles ---
+
+type roleSorter []data.Role
+
+func (r roleSorter) Len() int      { return len(r) }
+func (r roleSorter) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
+func (r roleSorter) Less(i, j int) bool {
+	return r[i].Name < r[j].Name
+}
+
+// Pretty-prints the sorted list of TargetWithRoles.
+func prettyPrintTargets(ts []*client.TargetWithRole, writer io.Writer) {
+	if len(ts) == 0 {
+		writer.Write([]byte("\nNo targets present in this repository.\n\n"))
+		return
+	}
+
+	sort.Stable(targetsSorter(ts))
+
+	tw := initTabWriter([]string{"NAME", "DIGEST", "SIZE (BYTES)", "ROLE"}, writer)
+
+	for _, t := range ts {
+		fmt.Fprintf(
+			tw,
+			fourItemRow,
+			t.Name,
+			hex.EncodeToString(t.Hashes["sha256"]),
+			fmt.Sprintf("%d", t.Length),
+			t.Role,
+		)
+	}
+	tw.Flush()
+}
+
+// Pretty-prints the list of provided Roles
+func prettyPrintRoles(rs []data.Role, writer io.Writer, roleType string) {
+	if len(rs) == 0 {
+		writer.Write([]byte(fmt.Sprintf("\nNo %s present in this repository.\n\n", roleType)))
+		return
+	}
+
+	// this sorter works for Role types
+	sort.Stable(roleSorter(rs))
+
+	tw := initTabWriter([]string{"ROLE", "PATHS", "KEY IDS", "THRESHOLD"}, writer)
+
+	for _, r := range rs {
+		var path, kid string
+		pp := prettyPaths(r.Paths)
+		if len(pp) > 0 {
+			path = pp[0]
+		}
+		if len(r.KeyIDs) > 0 {
+			kid = r.KeyIDs[0]
+		}
+		fmt.Fprintf(
+			tw,
+			fourItemRow,
+			r.Name,
+			path,
+			kid,
+			fmt.Sprintf("%v", r.Threshold),
+		)
+		printExtraRoleRows(tw, pp, r.KeyIDs)
+	}
+	tw.Flush()
+}
+
+func printExtraRoleRows(tw *tabwriter.Writer, paths, keyIDs []string) {
+	lPaths := len(paths)
+	lKeyIDs := len(keyIDs)
+	longer := len(keyIDs)
+	if len(paths) > len(keyIDs) {
+		longer = len(paths)
+	}
+	for i := 1; i < longer; i++ {
+		var path, kid string
+		if lPaths > i {
+			path = paths[i]
+		}
+		if lKeyIDs > i {
+			kid = keyIDs[i]
+		}
+		fmt.Fprintf(
+			tw,
+			fourItemRow,
+			"",
+			path,
+			kid,
+			"",
+		)
+	}
+}
+
+// Pretty-formats a list of delegation paths, and ensures the empty string is printed as "" in the console
+func prettyPaths(paths []string) []string {
+	// sort paths first
+	sort.Strings(paths)
+	pp := make([]string, 0, len(paths))
+	for _, path := range paths {
+		// manually escape "" and designate that it is all paths with an extra print <all paths>
+		if path == "" {
+			path = "\"\" <all paths>"
+		}
+		pp = append(pp, path)
+	}
+	return pp
+}

--- a/cmd/diff/prettyprint_test.go
+++ b/cmd/diff/prettyprint_test.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/theupdateframework/notary/client"
+	"github.com/theupdateframework/notary/passphrase"
+	"github.com/theupdateframework/notary/trustmanager"
+	"github.com/theupdateframework/notary/tuf/data"
+	"github.com/theupdateframework/notary/tuf/utils"
+)
+
+// --- tests for pretty printing keys ---
+
+func TestTruncateWithEllipsis(t *testing.T) {
+	digits := "1234567890"
+	// do not truncate
+	require.Equal(t, truncateWithEllipsis(digits, 10, true), digits)
+	require.Equal(t, truncateWithEllipsis(digits, 10, false), digits)
+	require.Equal(t, truncateWithEllipsis(digits, 11, true), digits)
+	require.Equal(t, truncateWithEllipsis(digits, 11, false), digits)
+
+	// left and right truncate
+	require.Equal(t, truncateWithEllipsis(digits, 8, true), "...67890")
+	require.Equal(t, truncateWithEllipsis(digits, 8, false), "12345...")
+}
+
+func TestKeyInfoSorter(t *testing.T) {
+	expected := []keyInfo{
+		{role: data.CanonicalRootRole, gun: "", keyID: "a", location: "i"},
+		{role: data.CanonicalRootRole, gun: "", keyID: "a", location: "j"},
+		{role: data.CanonicalRootRole, gun: "", keyID: "z", location: "z"},
+		{role: "a", gun: "a", keyID: "a", location: "y"},
+		{role: "b", gun: "a", keyID: "a", location: "y"},
+		{role: "b", gun: "a", keyID: "b", location: "y"},
+		{role: "b", gun: "a", keyID: "b", location: "z"},
+		{role: "a", gun: "b", keyID: "a", location: "z"},
+	}
+	jumbled := make([]keyInfo, len(expected))
+	// randomish indices
+	for j, e := range []int{3, 6, 1, 4, 0, 7, 5, 2} {
+		jumbled[j] = expected[e]
+	}
+
+	sort.Sort(keyInfoSorter(jumbled))
+	require.True(t, reflect.DeepEqual(expected, jumbled),
+		fmt.Sprintf("Expected %v, Got %v", expected, jumbled))
+}
+
+type otherMemoryStore struct {
+	trustmanager.GenericKeyStore
+}
+
+func (l *otherMemoryStore) Name() string {
+	return strings.Repeat("z", 70)
+}
+
+// If there are no keys in any of the key stores, a message that there are no
+// signing keys should be displayed.
+func TestPrettyPrintZeroKeys(t *testing.T) {
+	ret := passphrase.ConstantRetriever("pass")
+	emptyKeyStore := trustmanager.NewKeyMemoryStore(ret)
+
+	var b bytes.Buffer
+	prettyPrintKeys([]trustmanager.KeyStore{emptyKeyStore}, &b)
+	text, err := ioutil.ReadAll(&b)
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(string(text)), "\n")
+	require.Len(t, lines, 1)
+	require.Equal(t, "No signing keys found.", lines[0])
+}
+
+// Given a list of key stores, the keys should be pretty-printed with their
+// roles, locations, IDs, and guns first in sorted order in the key store
+func TestPrettyPrintRootAndSigningKeys(t *testing.T) {
+	ret := passphrase.ConstantRetriever("pass")
+	keyStores := []trustmanager.KeyStore{
+		trustmanager.NewKeyMemoryStore(ret),
+		&otherMemoryStore{GenericKeyStore: *trustmanager.NewKeyMemoryStore(ret)},
+	}
+
+	longNameShortened := "..." + strings.Repeat("z", 37)
+
+	keys := make([]data.PrivateKey, 4)
+	for i := 0; i < 4; i++ {
+		key, err := utils.GenerateED25519Key(rand.Reader)
+		require.NoError(t, err)
+		keys[i] = key
+	}
+
+	root := data.CanonicalRootRole
+
+	// add keys to the key stores
+	require.NoError(t, keyStores[0].AddKey(trustmanager.KeyInfo{Role: root, Gun: ""}, keys[0]))
+	require.NoError(t, keyStores[1].AddKey(trustmanager.KeyInfo{Role: root, Gun: ""}, keys[0]))
+	require.NoError(t, keyStores[0].AddKey(trustmanager.KeyInfo{Role: data.CanonicalTargetsRole, Gun: data.GUN(strings.Repeat("/a", 30))}, keys[1]))
+	require.NoError(t, keyStores[1].AddKey(trustmanager.KeyInfo{Role: data.CanonicalSnapshotRole, Gun: "short/gun"}, keys[1]))
+	require.NoError(t, keyStores[0].AddKey(trustmanager.KeyInfo{Role: "targets/a", Gun: ""}, keys[3]))
+	require.NoError(t, keyStores[0].AddKey(trustmanager.KeyInfo{Role: "invalidRole", Gun: ""}, keys[2]))
+
+	expected := [][]string{
+		// root always comes first
+		{root.String(), keys[0].ID(), keyStores[0].Name()},
+		{root.String(), keys[0].ID(), longNameShortened},
+		// these have no gun, so they come first
+		{"invalidRole", keys[2].ID(), keyStores[0].Name()},
+		{"targets/a", keys[3].ID(), keyStores[0].Name()},
+		// these have guns, and are sorted then by guns
+		{data.CanonicalTargetsRole.String(), "..." + strings.Repeat("/a", 11), keys[1].ID(), keyStores[0].Name()},
+		{data.CanonicalSnapshotRole.String(), "short/gun", keys[1].ID(), longNameShortened},
+	}
+
+	var b bytes.Buffer
+	prettyPrintKeys(keyStores, &b)
+	text, err := ioutil.ReadAll(&b)
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(string(text)), "\n")
+	require.Len(t, lines, len(expected)+2)
+
+	// starts with headers
+	require.True(t, reflect.DeepEqual(strings.Fields(lines[0]),
+		[]string{"ROLE", "GUN", "KEY", "ID", "LOCATION"}))
+	require.Equal(t, "----", lines[1][:4])
+
+	for i, line := range lines[2:] {
+		// we are purposely not putting spaces in test data so easier to split
+		splitted := strings.Fields(line)
+		for j, v := range splitted {
+			require.Equal(t, expected[i][j], strings.TrimSpace(v))
+		}
+	}
+}
+
+// --- tests for pretty printing targets ---
+
+// If there are no targets, no table is printed, only a line saying that there
+// are no targets.
+func TestPrettyPrintZeroTargets(t *testing.T) {
+	var b bytes.Buffer
+	prettyPrintTargets([]*client.TargetWithRole{}, &b)
+	text, err := ioutil.ReadAll(&b)
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(string(text)), "\n")
+	require.Len(t, lines, 1)
+	require.Equal(t, "No targets present in this repository.", lines[0])
+
+}
+
+// Targets are sorted by name, and the name, SHA256 digest, size, and role are
+// printed.
+func TestPrettyPrintSortedTargets(t *testing.T) {
+	hashes := make([][]byte, 3)
+	var err error
+	for i, letter := range []string{"a012", "b012", "c012"} {
+		hashes[i], err = hex.DecodeString(letter)
+		require.NoError(t, err)
+	}
+	unsorted := []*client.TargetWithRole{
+		{Target: client.Target{Name: "zebra", Hashes: data.Hashes{"sha256": hashes[0]}, Length: 8}, Role: "targets/b"},
+		{Target: client.Target{Name: "aardvark", Hashes: data.Hashes{"sha256": hashes[1]}, Length: 1},
+			Role: "targets"},
+		{Target: client.Target{Name: "bee", Hashes: data.Hashes{"sha256": hashes[2]}, Length: 5}, Role: "targets/a"},
+	}
+
+	var b bytes.Buffer
+	prettyPrintTargets(unsorted, &b)
+	text, err := ioutil.ReadAll(&b)
+	require.NoError(t, err)
+
+	expected := [][]string{
+		{"aardvark", "b012", "1", "targets"},
+		{"bee", "c012", "5", "targets/a"},
+		{"zebra", "a012", "8", "targets/b"},
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(text)), "\n")
+	require.Len(t, lines, len(expected)+2)
+
+	// starts with headers
+	require.True(t, reflect.DeepEqual(strings.Fields(lines[0]), strings.Fields(
+		"NAME     DIGEST      SIZE (BYTES)   ROLE")))
+	require.Equal(t, "----", lines[1][:4])
+
+	for i, line := range lines[2:] {
+		splitted := strings.Fields(line)
+		require.Equal(t, expected[i], splitted)
+	}
+}
+
+// --- tests for pretty printing roles ---
+
+// If there are no roles, no table is printed, only a line saying that there
+// are no roles.
+func TestPrettyPrintZeroRoles(t *testing.T) {
+	var b bytes.Buffer
+	prettyPrintRoles([]data.Role{}, &b, "delegations")
+	text, err := ioutil.ReadAll(&b)
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(string(text)), "\n")
+	require.Len(t, lines, 1)
+	require.Equal(t, "No delegations present in this repository.", lines[0])
+}
+
+// Roles are sorted by name, and the name, paths, and KeyIDs are printed.
+func TestPrettyPrintSortedRoles(t *testing.T) {
+	var err error
+
+	unsorted := []data.Role{
+		{Name: "targets/zebra", Paths: []string{"stripes", "black", "white"}, RootRole: data.RootRole{KeyIDs: []string{"101"}, Threshold: 1}},
+		{Name: "targets/aardvark/unicorn/pony", Paths: []string{"rainbows"}, RootRole: data.RootRole{KeyIDs: []string{"135"}, Threshold: 1}},
+		{Name: "targets/bee", Paths: []string{"honey"}, RootRole: data.RootRole{KeyIDs: []string{"246"}, Threshold: 1}},
+		{Name: "targets/bee/wasp", Paths: []string{"honey/sting", "stuff"}, RootRole: data.RootRole{KeyIDs: []string{"246", "468"}, Threshold: 1}},
+	}
+
+	var b bytes.Buffer
+	prettyPrintRoles(unsorted, &b, "delegations")
+	text, err := ioutil.ReadAll(&b)
+	require.NoError(t, err)
+
+	expected := [][]string{
+		{"targets/aardvark/unicorn/pony", "rainbows", "135", "1"},
+		{"targets/bee", "honey", "246", "1"},
+		{"targets/bee/wasp", "honey/sting", "246", "1"},
+		{"stuff", "468"}, // Extra keys and paths are printed to extra rows
+		{"targets/zebra", "black", "101", "1"},
+		{"stripes"},
+		{"white"},
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(text)), "\n")
+	require.Len(t, lines, len(expected)+2)
+
+	// starts with headers
+	require.True(t, reflect.DeepEqual(strings.Fields(lines[0]), strings.Fields(
+		"ROLE     PATHS      KEY IDS   THRESHOLD")))
+	require.Equal(t, "----", lines[1][:4])
+
+	for i, line := range lines[2:] {
+		splitted := strings.Fields(line)
+		require.Equal(t, expected[i], splitted)
+	}
+}

--- a/cmd/diff/repo_factory.go
+++ b/cmd/diff/repo_factory.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"github.com/spf13/viper"
+
+	"net/http"
+
+	"github.com/theupdateframework/notary"
+	"github.com/theupdateframework/notary/client"
+	"github.com/theupdateframework/notary/tuf/data"
+)
+
+const remoteConfigField = "api"
+
+// RepoFactory takes a GUN and returns an initialized client.Repository, or an error.
+type RepoFactory func(gun data.GUN) (client.Repository, error)
+
+// ConfigureRepo takes in the configuration parameters and returns a repoFactory that can
+// initialize new client.Repository objects with the correct upstreams and password
+// retrieval mechanisms.
+func ConfigureRepo(v *viper.Viper, retriever notary.PassRetriever, onlineOperation bool) RepoFactory {
+	localRepo := func(gun data.GUN) (client.Repository, error) {
+		var rt http.RoundTripper
+		trustPin, err := getTrustPinning(v)
+		if err != nil {
+			return nil, err
+		}
+		if onlineOperation {
+			rt, err = getTransport(v, gun, admin)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return client.NewFileCachedRepository(
+			v.GetString("trust_dir"),
+			gun,
+			getRemoteTrustServer(v),
+			rt,
+			retriever,
+			trustPin,
+		)
+	}
+
+	return localRepo
+}

--- a/tuf/builder.go
+++ b/tuf/builder.go
@@ -32,6 +32,14 @@ type ConsistentInfo struct {
 	fileMeta data.FileMeta
 }
 
+// NewConsistentInfo creates a new instance of ConsistentInfo
+func NewConsistentInfo(role data.RoleName, fm data.FileMeta) ConsistentInfo {
+	return ConsistentInfo{
+		RoleName: role,
+		fileMeta: fm,
+	}
+}
+
 // ChecksumKnown determines whether or not we know enough to provide a size and
 // consistent name
 func (c ConsistentInfo) ChecksumKnown() bool {

--- a/vendor.conf
+++ b/vendor.conf
@@ -26,7 +26,7 @@ github.com/spf13/cobra              f368244301305f414206f889b1735a54cfc8bde8
 github.com/spf13/viper              be5ff3e4840cf692388bde7a057595a474ef379e
 golang.org/x/crypto                 76eec36fa14229c4b25bb894c2d0e591527af429
 golang.org/x/net                    6a513affb38dc9788b449d59ffed099b8de18fa0
-golang.org/x/sys                    739734461d1c916b6c72a63d7efda2b27edb369f
+golang.org/x/sys                    d4266bc12aae0b4128952c889b769442fce5d2f1
 google.golang.org/grpc              708a7f9f3283aa2d4f6132d287d78683babe55c8   # v1.0.5
 github.com/pkg/errors 		    839d9e913e063e28dfd0e6c7b7512793e0a48be9
 


### PR DESCRIPTION
Using two timestamp checksums found from a changefeed (or known through some other means), this PR creates a new command:

`diff <gun> <ts checksum> <ts checksum>`

It takes all the typical arguments of the `notary` command including `-s` for the server, `--tlscacert`. It does not need a `-d` as it operates entirely in memory, outputting the a diff as a JSON blob with the following 6 fields:

```
{
    "TargetsAdded": <null of []client.TargetSignedStruct>,
    "TargetsUpdated": <null of []client.TargetSignedStruct>,
    "TargetsRemoved": <null of []client.TargetSignedStruct>,
    "RolesAdded": <null or []data.Role>,
    "RolesUpdated": <null or []data.Role>,
    "RolesRemoved": <null or []data.Role>
}
```

TODOs:
-[ ] Cleanup CLI help text, it's inconsistent with things like the command being referenced as `notarydiff` (I couldn't decide on the best name).
-[ ] Verify checksums in the findRoot function.
-[ ] Provide a `-o` option to output the diff to a file. Because of the interactivity with registry login, piping and directing stdout don't work.

cc @clemenko 