### PR TITLE
changefeed: error with 400 for nonexistent change_id

### DIFF
--- a/server/storage/rethink_realdb_test.go
+++ b/server/storage/rethink_realdb_test.go
@@ -177,3 +177,15 @@ func TestRethinkDBGetChanges(t *testing.T) {
 
 	testGetChanges(t, dbStore)
 }
+
+func TestRethinkDBGetChangesRequiresChangeID(t *testing.T) {
+	dbStore, cleanup := rethinkDBSetup(t)
+	defer cleanup()
+
+	blackoutTime = 0
+	// empty changeID
+	c, err := dbStore.GetChanges("", 10, "")
+	require.Error(t, err)
+	require.Equal(t, err, ErrBadQuery{"must specify change ID parameter for rethinkdb backend"})
+	require.Len(t, c, 0)
+}

--- a/server/storage/rethinkdb.go
+++ b/server/storage/rethinkdb.go
@@ -365,6 +365,8 @@ func (rdb RethinkDB) GetChanges(changeID string, pageSize int, filterName string
 	}
 
 	switch changeID {
+	case "":
+		return nil, ErrBadQuery{"must specify change ID parameter for rethinkdb backend"}
 	case "0", "-1":
 		lower = min
 		upper = max


### PR DESCRIPTION
Check early that the `change_id` parameter exists for rethinkdb instead of returning a 500 on a query error.

Closes https://github.com/theupdateframework/notary/issues/1257

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>