### PR TITLE
Update Go to 1.9.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.4
+FROM golang:1.9.4
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/buildscripts/cross.sh
+++ b/buildscripts/cross.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # This script cross-compiles static (when possible) binaries for supported OS's
 # architectures.  The Linux binary is completely static, whereas Mac OS binary
 # has libtool statically linked in. but is otherwise not static because you

--- a/cross.Dockerfile
+++ b/cross.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.4
+FROM golang:1.9.4
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/cross.Dockerfile
+++ b/cross.Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.9.4
 RUN apt-get update && apt-get install -y \
 	curl \
 	clang \
+	file \
 	libltdl-dev \
 	libsqlite3-dev \
 	patch \
@@ -19,7 +20,7 @@ RUN useradd -ms /bin/bash notary \
 
 # Configure the container for OSX cross compilation
 ENV OSX_SDK MacOSX10.11.sdk
-ENV OSX_CROSS_COMMIT 8aa9b71a394905e6c5f4b59e2b97b87a004658a4
+ENV OSX_CROSS_COMMIT 1a1733a773fe26e7b6c93b16fbf9341f22fac831
 RUN set -x \
 	&& export OSXCROSS_PATH="/osxcross" \
 	&& git clone https://github.com/tpoechtrager/osxcross.git $OSXCROSS_PATH \

--- a/escrow.Dockerfile
+++ b/escrow.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.3-alpine
+FROM golang:1.9.4-alpine
 MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 ENV NOTARYPKG github.com/theupdateframework/notary

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.4-alpine
+FROM golang:1.9.4-alpine
 MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 RUN apk add --update git gcc libc-dev && rm -rf /var/cache/apk/*

--- a/signer.Dockerfile
+++ b/signer.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.4-alpine
+FROM golang:1.9.4-alpine
 MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 RUN apk add --update git gcc libc-dev && rm -rf /var/cache/apk/*

--- a/vendor.conf
+++ b/vendor.conf
@@ -15,7 +15,7 @@ github.com/jinzhu/gorm              5409931a1bb87e484d68d649af9367c207713ea2
 github.com/jinzhu/inflection        1c35d901db3da928c72a72d8458480cc9ade058f
 github.com/lib/pq                   0dad96c0b94f8dee039aa40467f767467392a0af
 github.com/mattn/go-sqlite3         b4142c444a8941d0d92b0b7103a24df9cd815e42   # v1.0.0
-github.com/miekg/pkcs11             ba39b9c6300b7e0be41b115330145ef8afdff7d6
+github.com/miekg/pkcs11             5f6e0d0dad6f472df908c8e968a98ef00c9224bb
 github.com/mitchellh/go-homedir     df55a15e5ce646808815381b3db47a8c66ea62f4
 github.com/prometheus/client_golang 449ccefff16c8e2b7229f6be1921ba22f62461fe
 github.com/prometheus/client_model  fa8ad6fec33561be4280a8f0514318c79d7f6cb6   # model-0.0.2-12-gfa8ad6f

--- a/vendor/github.com/miekg/pkcs11/README.md
+++ b/vendor/github.com/miekg/pkcs11/README.md
@@ -1,4 +1,4 @@
-# PKCS#11 [![Build Status](https://travis-ci.org/miekg/pkcs11.png?branch=master)](https://travis-ci.org/miekg/pkcs11)
+# PKCS#11 [![Build Status](https://travis-ci.org/miekg/pkcs11.png?branch=master)](https://travis-ci.org/miekg/pkcs11) [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/miekg/pkcs11)
 
 This is a Go implementation of the PKCS#11 API. It wraps the library closely, but uses Go idiom
 were it makes sense. It has been tested with SoftHSM.
@@ -57,6 +57,10 @@ A skeleton program would look somewhat like this (yes, pkcs#11 is verbose):
     fmt.Println()
 
 Further examples are included in the tests.
+
+To expose PKCS#11 keys using the
+[crypto.Signer interface](https://golang.org/pkg/crypto/#Signer),
+please see [github.com/thalesignite/crypto11](https://github.com/thalesignite/crypto11).
 
 # TODO
 

--- a/vendor/github.com/miekg/pkcs11/const.go
+++ b/vendor/github.com/miekg/pkcs11/const.go
@@ -23,6 +23,18 @@ const (
 	CKO_VENDOR_DEFINED    uint = 0x80000000
 )
 
+const (
+	CKG_MGF1_SHA1         uint = 0x00000001
+	CKG_MGF1_SHA224       uint = 0x00000005
+	CKG_MGF1_SHA256       uint = 0x00000002
+	CKG_MGF1_SHA384       uint = 0x00000003
+	CKG_MGF1_SHA512       uint = 0x00000004
+)
+
+const (
+	CKZ_DATA_SPECIFIED    uint = 0x00000001
+)
+
 // Generated with: awk '/#define CK[AFKMRC]/{ print $2 " = " $3 }' pkcs11t.h | sed -e 's/UL$//g' -e 's/UL)$/)/g'
 
 // All the flag (CKF_), attribute (CKA_), error code (CKR_), key type (CKK_), certificate type (CKC_) and
@@ -86,11 +98,11 @@ const (
 	CKK_SHA512_224_HMAC                  = 0x00000027
 	CKK_SHA512_256_HMAC                  = 0x00000028
 	CKK_SHA512_T_HMAC                    = 0x00000029
-	CKK_SHA_1_HMAC                       = 0x00000040
-	CKK_SHA224_HMAC                      = 0x00000041
-	CKK_SHA256_HMAC                      = 0x00000042
-	CKK_SHA384_HMAC                      = 0x00000043
-	CKK_SHA512_HMAC                      = 0x00000044
+        CKK_SHA_1_HMAC                       = 0x00000028
+        CKK_SHA224_HMAC                      = 0x0000002E
+        CKK_SHA256_HMAC                      = 0x0000002B
+        CKK_SHA384_HMAC                      = 0x0000002C
+        CKK_SHA512_HMAC                      = 0x0000002D
 	CKK_SEED                             = 0x00000050
 	CKK_GOSTR3410                        = 0x00000060
 	CKK_GOSTR3411                        = 0x00000061
@@ -472,6 +484,10 @@ const (
 	CKM_EC_KEY_PAIR_GEN                  = 0x00001040
 	CKM_ECDSA                            = 0x00001041
 	CKM_ECDSA_SHA1                       = 0x00001042
+	CKM_ECDSA_SHA224                     = 0x00001043
+	CKM_ECDSA_SHA256                     = 0x00001044
+	CKM_ECDSA_SHA384                     = 0x00001045
+	CKM_ECDSA_SHA512                     = 0x00001046
 	CKM_ECDH1_DERIVE                     = 0x00001050
 	CKM_ECDH1_COFACTOR_DERIVE            = 0x00001051
 	CKM_ECMQV_DERIVE                     = 0x00001052

--- a/vendor/github.com/miekg/pkcs11/pkcs11.go
+++ b/vendor/github.com/miekg/pkcs11/pkcs11.go
@@ -11,22 +11,21 @@ package pkcs11
 // * CK_ULONG never overflows an Go int
 
 /*
-#cgo windows LDFLAGS: -Wl,--no-as-needed -lltdl
-#cgo linux LDFLAGS: -Wl,--no-as-needed -lltdl -ldl
+#cgo windows CFLAGS: -DREPACK_STRUCTURES
+#cgo windows LDFLAGS: -lltdl
+#cgo linux LDFLAGS: -lltdl -ldl
 #cgo darwin CFLAGS: -I/usr/local/share/libtool
-#cgo darwin LDFLAGS: -lltdl -L/usr/local/lib/ -I/usr/local/share/libtool
+#cgo darwin LDFLAGS: -lltdl -L/usr/local/lib/
+#cgo openbsd CFLAGS: -I/usr/local/include/
+#cgo openbsd LDFLAGS: -lltdl -L/usr/local/lib/
 #cgo LDFLAGS: -lltdl
-#define CK_PTR *
-#define CK_DEFINE_FUNCTION(returnType, name) returnType name
-#define CK_DECLARE_FUNCTION(returnType, name) returnType name
-#define CK_DECLARE_FUNCTION_POINTER(returnType, name) returnType (* name)
-#define CK_CALLBACK_FUNCTION(returnType, name) returnType (* name)
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <ltdl.h>
 #include <unistd.h>
-#include "pkcs11.h"
+#include "pkcs11go.h"
 
 struct ctx {
 	lt_dlhandle handle;
@@ -71,9 +70,12 @@ void Destroy(struct ctx *c)
 	free(c);
 }
 
-CK_RV Initialize(struct ctx * c, CK_VOID_PTR initArgs)
+CK_RV Initialize(struct ctx * c)
 {
-	return c->sym->C_Initialize(initArgs);
+	CK_C_INITIALIZE_ARGS args;
+	memset(&args, 0, sizeof(args));
+	args.flags = CKF_OS_LOCKING_OK;
+	return c->sym->C_Initialize(&args);
 }
 
 CK_RV Finalize(struct ctx * c)
@@ -81,9 +83,19 @@ CK_RV Finalize(struct ctx * c)
 	return c->sym->C_Finalize(NULL);
 }
 
-CK_RV GetInfo(struct ctx * c, CK_INFO_PTR info)
+CK_RV GetInfo(struct ctx * c, ckInfoPtr info)
 {
-	return c->sym->C_GetInfo(info);
+	CK_INFO p;
+	CK_RV e = c->sym->C_GetInfo(&p);
+	if (e != CKR_OK) {
+		return e;
+	}
+	info->cryptokiVersion = p.cryptokiVersion;
+	memcpy(info->manufacturerID, p.manufacturerID, sizeof(p.manufacturerID));
+	info->flags = p.flags;
+	memcpy(info->libraryDescription, p.libraryDescription, sizeof(p.libraryDescription));
+	info->libraryVersion = p.libraryVersion;
+	return e;
 }
 
 CK_RV GetSlotList(struct ctx * c, CK_BBOOL tokenPresent,
@@ -115,7 +127,8 @@ CK_RV GetMechanismList(struct ctx * c, CK_ULONG slotID,
 {
 	CK_RV e =
 	    c->sym->C_GetMechanismList((CK_SLOT_ID) slotID, NULL, mechlen);
-	if (e != CKR_OK) {
+	// Gemaltos PKCS11 implementation returns CKR_BUFFER_TOO_SMALL on a NULL ptr instad of CKR_OK as the spec states.
+	if (e != CKR_OK && e != CKR_BUFFER_TOO_SMALL) {
 		return e;
 	}
 	*mech = calloc(*mechlen, sizeof(CK_MECHANISM_TYPE));
@@ -223,18 +236,22 @@ CK_RV Logout(struct ctx * c, CK_SESSION_HANDLE session)
 }
 
 CK_RV CreateObject(struct ctx * c, CK_SESSION_HANDLE session,
-		   CK_ATTRIBUTE_PTR temp, CK_ULONG tempCount,
+		   ckAttrPtr temp, CK_ULONG tempCount,
 		   CK_OBJECT_HANDLE_PTR obj)
 {
-	CK_RV e = c->sym->C_CreateObject(session, temp, tempCount, obj);
+	ATTR_TO_C(tempc, temp, tempCount, NULL);
+	CK_RV e = c->sym->C_CreateObject(session, tempc, tempCount, obj);
+	ATTR_FREE(tempc);
 	return e;
 }
 
 CK_RV CopyObject(struct ctx * c, CK_SESSION_HANDLE session, CK_OBJECT_HANDLE o,
-		 CK_ATTRIBUTE_PTR temp, CK_ULONG tempCount,
+		 ckAttrPtr temp, CK_ULONG tempCount,
 		 CK_OBJECT_HANDLE_PTR obj)
 {
-	CK_RV e = c->sym->C_CopyObject(session, o, temp, tempCount, obj);
+	ATTR_TO_C(tempc, temp, tempCount, NULL);
+	CK_RV e = c->sym->C_CopyObject(session, o, tempc, tempCount, obj);
+	ATTR_FREE(tempc);
 	return e;
 }
 
@@ -253,39 +270,47 @@ CK_RV GetObjectSize(struct ctx * c, CK_SESSION_HANDLE session,
 }
 
 CK_RV GetAttributeValue(struct ctx * c, CK_SESSION_HANDLE session,
-			CK_OBJECT_HANDLE object, CK_ATTRIBUTE_PTR temp,
+			CK_OBJECT_HANDLE object, ckAttrPtr temp,
 			CK_ULONG templen)
 {
+	ATTR_TO_C(tempc, temp, templen, NULL);
 	// Call for the first time, check the returned ulValue in the attributes, then
 	// allocate enough space and try again.
-	CK_RV e = c->sym->C_GetAttributeValue(session, object, temp, templen);
+	CK_RV e = c->sym->C_GetAttributeValue(session, object, tempc, templen);
 	if (e != CKR_OK) {
+		ATTR_FREE(tempc);
 		return e;
 	}
 	CK_ULONG i;
 	for (i = 0; i < templen; i++) {
-		if ((CK_LONG) temp[i].ulValueLen == -1) {
+		if ((CK_LONG) tempc[i].ulValueLen == -1) {
 			// either access denied or no such object
 			continue;
 		}
-		temp[i].pValue = calloc(temp[i].ulValueLen, sizeof(CK_BYTE));
+		tempc[i].pValue = calloc(tempc[i].ulValueLen, sizeof(CK_BYTE));
 	}
-	e = c->sym->C_GetAttributeValue(session, object, temp, templen);
+	e = c->sym->C_GetAttributeValue(session, object, tempc, templen);
+	ATTR_FROM_C(temp, tempc, templen);
+	ATTR_FREE(tempc);
 	return e;
 }
 
 CK_RV SetAttributeValue(struct ctx * c, CK_SESSION_HANDLE session,
-			CK_OBJECT_HANDLE object, CK_ATTRIBUTE_PTR temp,
+			CK_OBJECT_HANDLE object, ckAttrPtr temp,
 			CK_ULONG templen)
 {
-	CK_RV e = c->sym->C_SetAttributeValue(session, object, temp, templen);
+	ATTR_TO_C(tempc, temp, templen, NULL);
+	CK_RV e = c->sym->C_SetAttributeValue(session, object, tempc, templen);
+	ATTR_FREE(tempc);
 	return e;
 }
 
 CK_RV FindObjectsInit(struct ctx * c, CK_SESSION_HANDLE session,
-		      CK_ATTRIBUTE_PTR temp, CK_ULONG tempCount)
+		      ckAttrPtr temp, CK_ULONG tempCount)
 {
-	CK_RV e = c->sym->C_FindObjectsInit(session, temp, tempCount);
+	ATTR_TO_C(tempc, temp, tempCount, NULL);
+	CK_RV e = c->sym->C_FindObjectsInit(session, tempc, tempCount);
+	ATTR_FREE(tempc);
 	return e;
 }
 
@@ -305,9 +330,10 @@ CK_RV FindObjectsFinal(struct ctx * c, CK_SESSION_HANDLE session)
 }
 
 CK_RV EncryptInit(struct ctx * c, CK_SESSION_HANDLE session,
-		  CK_MECHANISM_PTR mechanism, CK_OBJECT_HANDLE key)
+		  ckMechPtr mechanism, CK_OBJECT_HANDLE key)
 {
-	CK_RV e = c->sym->C_EncryptInit(session, mechanism, key);
+	MECH_TO_C(m, mechanism);
+	CK_RV e = c->sym->C_EncryptInit(session, m, key);
 	return e;
 }
 
@@ -360,9 +386,10 @@ CK_RV EncryptFinal(struct ctx * c, CK_SESSION_HANDLE session,
 }
 
 CK_RV DecryptInit(struct ctx * c, CK_SESSION_HANDLE session,
-		  CK_MECHANISM_PTR mechanism, CK_OBJECT_HANDLE key)
+		  ckMechPtr mechanism, CK_OBJECT_HANDLE key)
 {
-	CK_RV e = c->sym->C_DecryptInit(session, mechanism, key);
+	MECH_TO_C(m, mechanism);
+	CK_RV e = c->sym->C_DecryptInit(session, m, key);
 	return e;
 }
 
@@ -415,9 +442,10 @@ CK_RV DecryptFinal(struct ctx * c, CK_SESSION_HANDLE session,
 }
 
 CK_RV DigestInit(struct ctx * c, CK_SESSION_HANDLE session,
-		 CK_MECHANISM_PTR mechanism)
+		 ckMechPtr mechanism)
 {
-	CK_RV e = c->sym->C_DigestInit(session, mechanism);
+	MECH_TO_C(m, mechanism);
+	CK_RV e = c->sym->C_DigestInit(session, m);
 	return e;
 }
 
@@ -465,9 +493,10 @@ CK_RV DigestFinal(struct ctx * c, CK_SESSION_HANDLE session, CK_BYTE_PTR * hash,
 }
 
 CK_RV SignInit(struct ctx * c, CK_SESSION_HANDLE session,
-	       CK_MECHANISM_PTR mechanism, CK_OBJECT_HANDLE key)
+	       ckMechPtr mechanism, CK_OBJECT_HANDLE key)
 {
-	CK_RV e = c->sym->C_SignInit(session, mechanism, key);
+	MECH_TO_C(m, mechanism);
+	CK_RV e = c->sym->C_SignInit(session, m, key);
 	return e;
 }
 
@@ -509,9 +538,10 @@ CK_RV SignFinal(struct ctx * c, CK_SESSION_HANDLE session, CK_BYTE_PTR * sig,
 }
 
 CK_RV SignRecoverInit(struct ctx * c, CK_SESSION_HANDLE session,
-		      CK_MECHANISM_PTR mech, CK_OBJECT_HANDLE key)
+		      ckMechPtr mech, CK_OBJECT_HANDLE key)
 {
-	CK_RV rv = c->sym->C_SignRecoverInit(session, mech, key);
+	MECH_TO_C(m, mech);
+	CK_RV rv = c->sym->C_SignRecoverInit(session, m, key);
 	return rv;
 }
 
@@ -531,9 +561,10 @@ CK_RV SignRecover(struct ctx * c, CK_SESSION_HANDLE session, CK_BYTE_PTR data,
 }
 
 CK_RV VerifyInit(struct ctx * c, CK_SESSION_HANDLE session,
-		 CK_MECHANISM_PTR mech, CK_OBJECT_HANDLE key)
+		 ckMechPtr mech, CK_OBJECT_HANDLE key)
 {
-	CK_RV rv = c->sym->C_VerifyInit(session, mech, key);
+	MECH_TO_C(m, mech);
+	CK_RV rv = c->sym->C_VerifyInit(session, m, key);
 	return rv;
 }
 
@@ -559,9 +590,10 @@ CK_RV VerifyFinal(struct ctx * c, CK_SESSION_HANDLE session, CK_BYTE_PTR sig,
 }
 
 CK_RV VerifyRecoverInit(struct ctx * c, CK_SESSION_HANDLE session,
-			CK_MECHANISM_PTR mech, CK_OBJECT_HANDLE key)
+			ckMechPtr mech, CK_OBJECT_HANDLE key)
 {
-	CK_RV rv = c->sym->C_VerifyRecoverInit(session, mech, key);
+	MECH_TO_C(m, mech);
+	CK_RV rv = c->sym->C_VerifyRecoverInit(session, m, key);
 	return rv;
 }
 
@@ -654,33 +686,39 @@ CK_RV DecryptVerifyUpdate(struct ctx * c, CK_SESSION_HANDLE session,
 }
 
 CK_RV GenerateKey(struct ctx * c, CK_SESSION_HANDLE session,
-		  CK_MECHANISM_PTR mechanism, CK_ATTRIBUTE_PTR temp,
+		  ckMechPtr mechanism, ckAttrPtr temp,
 		  CK_ULONG tempCount, CK_OBJECT_HANDLE_PTR key)
 {
-	CK_RV e =
-	    c->sym->C_GenerateKey(session, mechanism, temp, tempCount, key);
+	MECH_TO_C(m, mechanism);
+	ATTR_TO_C(tempc, temp, tempCount, NULL);
+	CK_RV e = c->sym->C_GenerateKey(session, m, tempc, tempCount, key);
+	ATTR_FREE(tempc);
 	return e;
 }
 
 CK_RV GenerateKeyPair(struct ctx * c, CK_SESSION_HANDLE session,
-		      CK_MECHANISM_PTR mechanism, CK_ATTRIBUTE_PTR pub,
-		      CK_ULONG pubCount, CK_ATTRIBUTE_PTR priv,
+		      ckMechPtr mechanism, ckAttrPtr pub,
+		      CK_ULONG pubCount, ckAttrPtr priv,
 		      CK_ULONG privCount, CK_OBJECT_HANDLE_PTR pubkey,
 		      CK_OBJECT_HANDLE_PTR privkey)
 {
-	CK_RV e =
-	    c->sym->C_GenerateKeyPair(session, mechanism, pub, pubCount, priv,
-				      privCount,
-				      pubkey, privkey);
+	MECH_TO_C(m, mechanism);
+	ATTR_TO_C(pubc, pub, pubCount, NULL);
+	ATTR_TO_C(privc, priv, privCount, pubc);
+	CK_RV e = c->sym->C_GenerateKeyPair(session, m, pubc, pubCount,
+		privc, privCount, pubkey, privkey);
+	ATTR_FREE(pubc);
+	ATTR_FREE(privc);
 	return e;
 }
 
 CK_RV WrapKey(struct ctx * c, CK_SESSION_HANDLE session,
-	      CK_MECHANISM_PTR mechanism, CK_OBJECT_HANDLE wrappingkey,
+	      ckMechPtr mechanism, CK_OBJECT_HANDLE wrappingkey,
 	      CK_OBJECT_HANDLE key, CK_BYTE_PTR * wrapped,
 	      CK_ULONG_PTR wrappedlen)
 {
-	CK_RV rv = c->sym->C_WrapKey(session, mechanism, wrappingkey, key, NULL,
+	MECH_TO_C(m, mechanism);
+	CK_RV rv = c->sym->C_WrapKey(session, m, wrappingkey, key, NULL,
 				     wrappedlen);
 	if (rv != CKR_OK) {
 		return rv;
@@ -689,26 +727,32 @@ CK_RV WrapKey(struct ctx * c, CK_SESSION_HANDLE session,
 	if (*wrapped == NULL) {
 		return CKR_HOST_MEMORY;
 	}
-	rv = c->sym->C_WrapKey(session, mechanism, wrappingkey, key, *wrapped,
+	rv = c->sym->C_WrapKey(session, m, wrappingkey, key, *wrapped,
 			       wrappedlen);
 	return rv;
 }
 
 CK_RV DeriveKey(struct ctx * c, CK_SESSION_HANDLE session,
-		CK_MECHANISM_PTR mech, CK_OBJECT_HANDLE basekey,
-		CK_ATTRIBUTE_PTR a, CK_ULONG alen, CK_OBJECT_HANDLE_PTR key)
+		ckMechPtr mech, CK_OBJECT_HANDLE basekey,
+		ckAttrPtr a, CK_ULONG alen, CK_OBJECT_HANDLE_PTR key)
 {
-	CK_RV e = c->sym->C_DeriveKey(session, mech, basekey, a, alen, key);
+	MECH_TO_C(m, mech);
+	ATTR_TO_C(tempc, a, alen, NULL);
+	CK_RV e = c->sym->C_DeriveKey(session, m, basekey, tempc, alen, key);
+	ATTR_FREE(tempc);
 	return e;
 }
 
 CK_RV UnwrapKey(struct ctx * c, CK_SESSION_HANDLE session,
-		CK_MECHANISM_PTR mech, CK_OBJECT_HANDLE unwrappingkey,
+		ckMechPtr mech, CK_OBJECT_HANDLE unwrappingkey,
 		CK_BYTE_PTR wrappedkey, CK_ULONG wrappedkeylen,
-		CK_ATTRIBUTE_PTR a, CK_ULONG alen, CK_OBJECT_HANDLE_PTR key)
+		ckAttrPtr a, CK_ULONG alen, CK_OBJECT_HANDLE_PTR key)
 {
-	CK_RV e = c->sym->C_UnwrapKey(session, mech, unwrappingkey, wrappedkey,
-				      wrappedkeylen, a, alen, key);
+	MECH_TO_C(m, mech);
+	ATTR_TO_C(tempc, a, alen, NULL);
+	CK_RV e = c->sym->C_UnwrapKey(session, m, unwrappingkey, wrappedkey,
+				      wrappedkeylen, tempc, alen, key);
+	ATTR_FREE(tempc);
 	return e;
 }
 
@@ -736,6 +780,38 @@ CK_RV WaitForSlotEvent(struct ctx * c, CK_FLAGS flags, CK_ULONG_PTR slot)
 	    c->sym->C_WaitForSlotEvent(flags, (CK_SLOT_ID_PTR) slot, NULL);
 	return e;
 }
+
+#ifdef REPACK_STRUCTURES
+
+CK_RV attrsToC(CK_ATTRIBUTE_PTR *attrOut, ckAttrPtr attrIn, CK_ULONG count) {
+	CK_ATTRIBUTE_PTR attr = calloc(count, sizeof(CK_ATTRIBUTE));
+	if (attr == NULL) {
+		return CKR_HOST_MEMORY;
+	}
+	for (int i = 0; i < count; i++) {
+		attr[i].type = attrIn[i].type;
+		attr[i].pValue = attrIn[i].pValue;
+		attr[i].ulValueLen = attrIn[i].ulValueLen;
+	}
+	*attrOut = attr;
+	return CKR_OK;
+}
+
+void attrsFromC(ckAttrPtr attrOut, CK_ATTRIBUTE_PTR attrIn, CK_ULONG count) {
+	for (int i = 0; i < count; i++) {
+		attrOut[i].type = attrIn[i].type;
+		attrOut[i].pValue = attrIn[i].pValue;
+		attrOut[i].ulValueLen = attrIn[i].ulValueLen;
+	}
+}
+
+void mechToC(CK_MECHANISM_PTR mechOut, ckMechPtr mechIn) {
+	mechOut->mechanism = mechIn->mechanism;
+	mechOut->pParameter = mechIn->pParameter;
+	mechOut->ulParameterLen = mechIn->ulParameterLen;
+}
+
+#endif
 */
 import "C"
 import "strings"
@@ -749,6 +825,11 @@ type Ctx struct {
 
 // New creates a new context and initializes the module/library for use.
 func New(module string) *Ctx {
+	// libtool-ltdl will return an assertion error if passed an empty string, so
+	// we check for it explicitly.
+	if module == "" {
+		return nil
+	}
 	c := new(Ctx)
 	mod := C.CString(module)
 	defer C.free(unsafe.Pointer(mod))
@@ -770,8 +851,7 @@ func (c *Ctx) Destroy() {
 
 /* Initialize initializes the Cryptoki library. */
 func (c *Ctx) Initialize() error {
-	args := &C.CK_C_INITIALIZE_ARGS{nil, nil, nil, nil, C.CKF_OS_LOCKING_OK, nil}
-	e := C.Initialize(c.ctx, C.CK_VOID_PTR(args))
+	e := C.Initialize(c.ctx)
 	return toError(e)
 }
 
@@ -786,8 +866,8 @@ func (c *Ctx) Finalize() error {
 
 /* GetInfo returns general information about Cryptoki. */
 func (c *Ctx) GetInfo() (Info, error) {
-	var p C.CK_INFO
-	e := C.GetInfo(c.ctx, C.CK_INFO_PTR(&p))
+	var p C.ckInfo
+	e := C.GetInfo(c.ctx, &p)
 	i := Info{
 		CryptokiVersion:    toVersion(p.cryptokiVersion),
 		ManufacturerID:     strings.TrimRight(string(C.GoBytes(unsafe.Pointer(&p.manufacturerID[0]), 32)), " "),
@@ -1042,11 +1122,11 @@ func (c *Ctx) GetObjectSize(sh SessionHandle, oh ObjectHandle) (uint, error) {
 func (c *Ctx) GetAttributeValue(sh SessionHandle, o ObjectHandle, a []*Attribute) ([]*Attribute, error) {
 	// copy the attribute list and make all the values nil, so that
 	// the C function can (allocate) fill them in
-	pa := make([]C.CK_ATTRIBUTE, len(a))
+	pa := make([]C.ckAttr, len(a))
 	for i := 0; i < len(a); i++ {
 		pa[i]._type = C.CK_ATTRIBUTE_TYPE(a[i].Type)
 	}
-	e := C.GetAttributeValue(c.ctx, C.CK_SESSION_HANDLE(sh), C.CK_OBJECT_HANDLE(o), C.CK_ATTRIBUTE_PTR(&pa[0]), C.CK_ULONG(len(a)))
+	e := C.GetAttributeValue(c.ctx, C.CK_SESSION_HANDLE(sh), C.CK_OBJECT_HANDLE(o), C.ckAttrPtr(&pa[0]), C.CK_ULONG(len(a)))
 	if toError(e) != nil {
 		return nil, toError(e)
 	}
@@ -1530,7 +1610,7 @@ func (c *Ctx) UnwrapKey(sh SessionHandle, m []*Mechanism, unwrappingkey ObjectHa
 	return ObjectHandle(key), toError(e)
 }
 
-// DeriveKey derives a key from a base key, creating a new key object. */
+// DeriveKey derives a key from a base key, creating a new key object.
 func (c *Ctx) DeriveKey(sh SessionHandle, m []*Mechanism, basekey ObjectHandle, a []*Attribute) (ObjectHandle, error) {
 	var key C.CK_OBJECT_HANDLE
 	attrarena, ac, aclen := cAttributeList(a)

--- a/vendor/github.com/miekg/pkcs11/pkcs11.h
+++ b/vendor/github.com/miekg/pkcs11/pkcs11.h
@@ -1,7 +1,12 @@
-/*
- * Copyright (C) OASIS Open 2014.  All rights reserved.
- * OASIS trademark, IPR and other policies apply.
- * http://www.oasis-open.org/policies-guidelines/ipr
+/* Copyright (c) OASIS Open 2016. All Rights Reserved./
+ * /Distributed under the terms of the OASIS IPR Policy,
+ * [http://www.oasis-open.org/policies-guidelines/ipr], AS-IS, WITHOUT ANY
+ * IMPLIED OR EXPRESS WARRANTY; there is no warranty of MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE or NONINFRINGEMENT of the rights of others.
+ */
+        
+/* Latest version of the specification:
+ * http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/pkcs11-base-v2.40.html
  */
 
 #ifndef _PKCS11_H_
@@ -12,14 +17,14 @@ extern "C" {
 #endif
 
 /* Before including this file (pkcs11.h) (or pkcs11t.h by
- * itself), 6 platform-specific macros must be defined.  These
+ * itself), 5 platform-specific macros must be defined.  These
  * macros are described below, and typical definitions for them
  * are also given.  Be advised that these definitions can depend
  * on both the platform and the compiler used (and possibly also
  * on whether a Cryptoki library is linked statically or
  * dynamically).
  *
- * In addition to defining these 6 macros, the packing convention
+ * In addition to defining these 5 macros, the packing convention
  * for Cryptoki structures should be set.  The Cryptoki
  * convention on packing is that structures should be 1-byte
  * aligned.
@@ -69,39 +74,7 @@ extern "C" {
  * #define CK_PTR *
  *
  *
- * 2. CK_DEFINE_FUNCTION(returnType, name): A macro which makes
- * an exportable Cryptoki library function definition out of a
- * return type and a function name.  It should be used in the
- * following fashion to define the exposed Cryptoki functions in
- * a Cryptoki library:
- *
- * CK_DEFINE_FUNCTION(CK_RV, C_Initialize)(
- *   CK_VOID_PTR pReserved
- * )
- * {
- *   ...
- * }
- *
- * If you're using Microsoft Developer Studio 5.0 to define a
- * function in a Win32 Cryptoki .dll, it might be defined by:
- *
- * #define CK_DEFINE_FUNCTION(returnType, name) \
- *   returnType __declspec(dllexport) name
- *
- * If you're using an earlier version of Microsoft Developer
- * Studio to define a function in a Win16 Cryptoki .dll, it
- * might be defined by:
- *
- * #define CK_DEFINE_FUNCTION(returnType, name) \
- *   returnType __export _far _pascal name
- *
- * In a UNIX environment, it might be defined by:
- *
- * #define CK_DEFINE_FUNCTION(returnType, name) \
- *   returnType name
- *
- *
- * 3. CK_DECLARE_FUNCTION(returnType, name): A macro which makes
+ * 2. CK_DECLARE_FUNCTION(returnType, name): A macro which makes
  * an importable Cryptoki library function declaration out of a
  * return type and a function name.  It should be used in the
  * following fashion:
@@ -129,7 +102,7 @@ extern "C" {
  *   returnType name
  *
  *
- * 4. CK_DECLARE_FUNCTION_POINTER(returnType, name): A macro
+ * 3. CK_DECLARE_FUNCTION_POINTER(returnType, name): A macro
  * which makes a Cryptoki API function pointer declaration or
  * function pointer type declaration out of a return type and a
  * function name.  It should be used in the following fashion:
@@ -166,7 +139,7 @@ extern "C" {
  *   returnType (* name)
  *
  *
- * 5. CK_CALLBACK_FUNCTION(returnType, name): A macro which makes
+ * 4. CK_CALLBACK_FUNCTION(returnType, name): A macro which makes
  * a function pointer type for an application callback out of
  * a return type for the callback and a name for the callback.
  * It should be used in the following fashion:
@@ -198,7 +171,7 @@ extern "C" {
  *   returnType (* name)
  *
  *
- * 6. NULL_PTR: This macro is the value of a NULL pointer.
+ * 5. NULL_PTR: This macro is the value of a NULL pointer.
  *
  * In any ANSI/ISO C environment (and in many others as well),
  * this should best be defined by
@@ -210,7 +183,8 @@ extern "C" {
 
 
 /* All the various Cryptoki types and #define'd values are in the
- * file pkcs11t.h. */
+ * file pkcs11t.h.
+ */
 #include "pkcs11t.h"
 
 #define __PASTE(x,y)      x##y
@@ -226,7 +200,8 @@ extern "C" {
   extern CK_DECLARE_FUNCTION(CK_RV, name)
 
 /* pkcs11f.h has all the information about the Cryptoki
- * function prototypes. */
+ * function prototypes.
+ */
 #include "pkcs11f.h"
 
 #undef CK_NEED_ARG_LIST
@@ -245,7 +220,8 @@ extern "C" {
   typedef CK_DECLARE_FUNCTION_POINTER(CK_RV, __PASTE(CK_,name))
 
 /* pkcs11f.h has all the information about the Cryptoki
- * function prototypes. */
+ * function prototypes.
+ */
 #include "pkcs11f.h"
 
 #undef CK_NEED_ARG_LIST
@@ -270,7 +246,8 @@ struct CK_FUNCTION_LIST {
 
 /* Pile all the function pointers into the CK_FUNCTION_LIST. */
 /* pkcs11f.h has all the information about the Cryptoki
- * function prototypes. */
+ * function prototypes.
+ */
 #include "pkcs11f.h"
 
 };
@@ -284,4 +261,5 @@ struct CK_FUNCTION_LIST {
 }
 #endif
 
-#endif
+#endif /* _PKCS11_H_ */
+

--- a/vendor/github.com/miekg/pkcs11/pkcs11f.h
+++ b/vendor/github.com/miekg/pkcs11/pkcs11f.h
@@ -1,14 +1,20 @@
-/*
- * Copyright (C) OASIS Open 2014.  All rights reserved.
- * OASIS trademark, IPR and other policies apply.
- * http://www.oasis-open.org/policies-guidelines/ipr
+/* Copyright (c) OASIS Open 2016. All Rights Reserved./
+ * /Distributed under the terms of the OASIS IPR Policy,
+ * [http://www.oasis-open.org/policies-guidelines/ipr], AS-IS, WITHOUT ANY
+ * IMPLIED OR EXPRESS WARRANTY; there is no warranty of MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE or NONINFRINGEMENT of the rights of others.
+ */
+        
+/* Latest version of the specification:
+ * http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/pkcs11-base-v2.40.html
  */
 
-/* This header file contains pretty much everything about all the */
-/* Cryptoki function prototypes.  Because this information is */
-/* used for more than just declaring function prototypes, the */
-/* order of the functions appearing herein is important, and */
-/* should not be altered. */
+/* This header file contains pretty much everything about all the
+ * Cryptoki function prototypes.  Because this information is
+ * used for more than just declaring function prototypes, the
+ * order of the functions appearing herein is important, and
+ * should not be altered.
+ */
 
 /* General-purpose */
 
@@ -18,13 +24,15 @@ CK_PKCS11_FUNCTION_INFO(C_Initialize)
 (
   CK_VOID_PTR   pInitArgs  /* if this is not NULL_PTR, it gets
                             * cast to CK_C_INITIALIZE_ARGS_PTR
-                            * and dereferenced */
+                            * and dereferenced
+                            */
 );
 #endif
 
 
 /* C_Finalize indicates that an application is done with the
- * Cryptoki library. */
+ * Cryptoki library.
+ */
 CK_PKCS11_FUNCTION_INFO(C_Finalize)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -47,7 +55,8 @@ CK_PKCS11_FUNCTION_INFO(C_GetFunctionList)
 #ifdef CK_NEED_ARG_LIST
 (
   CK_FUNCTION_LIST_PTR_PTR ppFunctionList  /* receives pointer to
-                                            * function list */
+                                            * function list
+                                            */
 );
 #endif
 
@@ -59,7 +68,7 @@ CK_PKCS11_FUNCTION_INFO(C_GetFunctionList)
 CK_PKCS11_FUNCTION_INFO(C_GetSlotList)
 #ifdef CK_NEED_ARG_LIST
 (
-  CK_BBOOL       tokenPresent,  /* only slots with tokens? */
+  CK_BBOOL       tokenPresent,  /* only slots with tokens */
   CK_SLOT_ID_PTR pSlotList,     /* receives array of slot IDs */
   CK_ULONG_PTR   pulCount       /* receives number of slots */
 );
@@ -67,7 +76,8 @@ CK_PKCS11_FUNCTION_INFO(C_GetSlotList)
 
 
 /* C_GetSlotInfo obtains information about a particular slot in
- * the system. */
+ * the system.
+ */
 CK_PKCS11_FUNCTION_INFO(C_GetSlotInfo)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -78,7 +88,8 @@ CK_PKCS11_FUNCTION_INFO(C_GetSlotInfo)
 
 
 /* C_GetTokenInfo obtains information about a particular token
- * in the system. */
+ * in the system.
+ */
 CK_PKCS11_FUNCTION_INFO(C_GetTokenInfo)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -89,7 +100,8 @@ CK_PKCS11_FUNCTION_INFO(C_GetTokenInfo)
 
 
 /* C_GetMechanismList obtains a list of mechanism types
- * supported by a token. */
+ * supported by a token.
+ */
 CK_PKCS11_FUNCTION_INFO(C_GetMechanismList)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -101,7 +113,8 @@ CK_PKCS11_FUNCTION_INFO(C_GetMechanismList)
 
 
 /* C_GetMechanismInfo obtains information about a particular
- * mechanism possibly supported by a token. */
+ * mechanism possibly supported by a token.
+ */
 CK_PKCS11_FUNCTION_INFO(C_GetMechanismInfo)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -115,7 +128,6 @@ CK_PKCS11_FUNCTION_INFO(C_GetMechanismInfo)
 /* C_InitToken initializes a token. */
 CK_PKCS11_FUNCTION_INFO(C_InitToken)
 #ifdef CK_NEED_ARG_LIST
-/* pLabel changed from CK_CHAR_PTR to CK_UTF8CHAR_PTR for v2.10 */
 (
   CK_SLOT_ID      slotID,    /* ID of the token's slot */
   CK_UTF8CHAR_PTR pPin,      /* the SO's initial PIN */
@@ -153,7 +165,8 @@ CK_PKCS11_FUNCTION_INFO(C_SetPIN)
 /* Session management */
 
 /* C_OpenSession opens a session between an application and a
- * token. */
+ * token.
+ */
 CK_PKCS11_FUNCTION_INFO(C_OpenSession)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -167,7 +180,8 @@ CK_PKCS11_FUNCTION_INFO(C_OpenSession)
 
 
 /* C_CloseSession closes a session between an application and a
- * token. */
+ * token.
+ */
 CK_PKCS11_FUNCTION_INFO(C_CloseSession)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -196,7 +210,8 @@ CK_PKCS11_FUNCTION_INFO(C_GetSessionInfo)
 
 
 /* C_GetOperationState obtains the state of the cryptographic operation
- * in a session. */
+ * in a session.
+ */
 CK_PKCS11_FUNCTION_INFO(C_GetOperationState)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -208,7 +223,8 @@ CK_PKCS11_FUNCTION_INFO(C_GetOperationState)
 
 
 /* C_SetOperationState restores the state of the cryptographic
- * operation in a session. */
+ * operation in a session.
+ */
 CK_PKCS11_FUNCTION_INFO(C_SetOperationState)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -258,7 +274,8 @@ CK_PKCS11_FUNCTION_INFO(C_CreateObject)
 
 
 /* C_CopyObject copies an object, creating a new object for the
- * copy. */
+ * copy.
+ */
 CK_PKCS11_FUNCTION_INFO(C_CopyObject)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -293,7 +310,8 @@ CK_PKCS11_FUNCTION_INFO(C_GetObjectSize)
 
 
 /* C_GetAttributeValue obtains the value of one or more object
- * attributes. */
+ * attributes.
+ */
 CK_PKCS11_FUNCTION_INFO(C_GetAttributeValue)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -306,7 +324,8 @@ CK_PKCS11_FUNCTION_INFO(C_GetAttributeValue)
 
 
 /* C_SetAttributeValue modifies the value of one or more object
- * attributes */
+ * attributes.
+ */
 CK_PKCS11_FUNCTION_INFO(C_SetAttributeValue)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -319,7 +338,8 @@ CK_PKCS11_FUNCTION_INFO(C_SetAttributeValue)
 
 
 /* C_FindObjectsInit initializes a search for token and session
- * objects that match a template. */
+ * objects that match a template.
+ */
 CK_PKCS11_FUNCTION_INFO(C_FindObjectsInit)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -332,7 +352,8 @@ CK_PKCS11_FUNCTION_INFO(C_FindObjectsInit)
 
 /* C_FindObjects continues a search for token and session
  * objects that match a template, obtaining additional object
- * handles. */
+ * handles.
+ */
 CK_PKCS11_FUNCTION_INFO(C_FindObjects)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -345,7 +366,8 @@ CK_PKCS11_FUNCTION_INFO(C_FindObjects)
 
 
 /* C_FindObjectsFinal finishes a search for token and session
- * objects. */
+ * objects.
+ */
 CK_PKCS11_FUNCTION_INFO(C_FindObjectsFinal)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -382,7 +404,8 @@ CK_PKCS11_FUNCTION_INFO(C_Encrypt)
 
 
 /* C_EncryptUpdate continues a multiple-part encryption
- * operation. */
+ * operation.
+ */
 CK_PKCS11_FUNCTION_INFO(C_EncryptUpdate)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -396,7 +419,8 @@ CK_PKCS11_FUNCTION_INFO(C_EncryptUpdate)
 
 
 /* C_EncryptFinal finishes a multiple-part encryption
- * operation. */
+ * operation.
+ */
 CK_PKCS11_FUNCTION_INFO(C_EncryptFinal)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -432,7 +456,8 @@ CK_PKCS11_FUNCTION_INFO(C_Decrypt)
 
 
 /* C_DecryptUpdate continues a multiple-part decryption
- * operation. */
+ * operation.
+ */
 CK_PKCS11_FUNCTION_INFO(C_DecryptUpdate)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -446,7 +471,8 @@ CK_PKCS11_FUNCTION_INFO(C_DecryptUpdate)
 
 
 /* C_DecryptFinal finishes a multiple-part decryption
- * operation. */
+ * operation.
+ */
 CK_PKCS11_FUNCTION_INFO(C_DecryptFinal)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -484,7 +510,8 @@ CK_PKCS11_FUNCTION_INFO(C_Digest)
 
 
 /* C_DigestUpdate continues a multiple-part message-digesting
- * operation. */
+ * operation.
+ */
 CK_PKCS11_FUNCTION_INFO(C_DigestUpdate)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -497,7 +524,8 @@ CK_PKCS11_FUNCTION_INFO(C_DigestUpdate)
 
 /* C_DigestKey continues a multi-part message-digesting
  * operation, by digesting the value of a secret key as part of
- * the data already digested. */
+ * the data already digested.
+ */
 CK_PKCS11_FUNCTION_INFO(C_DigestKey)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -508,7 +536,8 @@ CK_PKCS11_FUNCTION_INFO(C_DigestKey)
 
 
 /* C_DigestFinal finishes a multiple-part message-digesting
- * operation. */
+ * operation.
+ */
 CK_PKCS11_FUNCTION_INFO(C_DigestFinal)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -525,7 +554,8 @@ CK_PKCS11_FUNCTION_INFO(C_DigestFinal)
 /* C_SignInit initializes a signature (private key encryption)
  * operation, where the signature is (will be) an appendix to
  * the data, and plaintext cannot be recovered from the
- *signature. */
+ * signature.
+ */
 CK_PKCS11_FUNCTION_INFO(C_SignInit)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -538,7 +568,8 @@ CK_PKCS11_FUNCTION_INFO(C_SignInit)
 
 /* C_Sign signs (encrypts with private key) data in a single
  * part, where the signature is (will be) an appendix to the
- * data, and plaintext cannot be recovered from the signature. */
+ * data, and plaintext cannot be recovered from the signature.
+ */
 CK_PKCS11_FUNCTION_INFO(C_Sign)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -553,7 +584,8 @@ CK_PKCS11_FUNCTION_INFO(C_Sign)
 
 /* C_SignUpdate continues a multiple-part signature operation,
  * where the signature is (will be) an appendix to the data,
- * and plaintext cannot be recovered from the signature. */
+ * and plaintext cannot be recovered from the signature.
+ */
 CK_PKCS11_FUNCTION_INFO(C_SignUpdate)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -565,7 +597,8 @@ CK_PKCS11_FUNCTION_INFO(C_SignUpdate)
 
 
 /* C_SignFinal finishes a multiple-part signature operation,
- * returning the signature. */
+ * returning the signature.
+ */
 CK_PKCS11_FUNCTION_INFO(C_SignFinal)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -577,7 +610,8 @@ CK_PKCS11_FUNCTION_INFO(C_SignFinal)
 
 
 /* C_SignRecoverInit initializes a signature operation, where
- * the data can be recovered from the signature. */
+ * the data can be recovered from the signature.
+ */
 CK_PKCS11_FUNCTION_INFO(C_SignRecoverInit)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -589,7 +623,8 @@ CK_PKCS11_FUNCTION_INFO(C_SignRecoverInit)
 
 
 /* C_SignRecover signs data in a single operation, where the
- * data can be recovered from the signature. */
+ * data can be recovered from the signature.
+ */
 CK_PKCS11_FUNCTION_INFO(C_SignRecover)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -607,7 +642,8 @@ CK_PKCS11_FUNCTION_INFO(C_SignRecover)
 
 /* C_VerifyInit initializes a verification operation, where the
  * signature is an appendix to the data, and plaintext cannot
- *  cannot be recovered from the signature (e.g. DSA). */
+ * cannot be recovered from the signature (e.g. DSA).
+ */
 CK_PKCS11_FUNCTION_INFO(C_VerifyInit)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -620,7 +656,8 @@ CK_PKCS11_FUNCTION_INFO(C_VerifyInit)
 
 /* C_Verify verifies a signature in a single-part operation,
  * where the signature is an appendix to the data, and plaintext
- * cannot be recovered from the signature. */
+ * cannot be recovered from the signature.
+ */
 CK_PKCS11_FUNCTION_INFO(C_Verify)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -635,7 +672,8 @@ CK_PKCS11_FUNCTION_INFO(C_Verify)
 
 /* C_VerifyUpdate continues a multiple-part verification
  * operation, where the signature is an appendix to the data,
- * and plaintext cannot be recovered from the signature. */
+ * and plaintext cannot be recovered from the signature.
+ */
 CK_PKCS11_FUNCTION_INFO(C_VerifyUpdate)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -647,7 +685,8 @@ CK_PKCS11_FUNCTION_INFO(C_VerifyUpdate)
 
 
 /* C_VerifyFinal finishes a multiple-part verification
- * operation, checking the signature. */
+ * operation, checking the signature.
+ */
 CK_PKCS11_FUNCTION_INFO(C_VerifyFinal)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -659,7 +698,8 @@ CK_PKCS11_FUNCTION_INFO(C_VerifyFinal)
 
 
 /* C_VerifyRecoverInit initializes a signature verification
- * operation, where the data is recovered from the signature. */
+ * operation, where the data is recovered from the signature.
+ */
 CK_PKCS11_FUNCTION_INFO(C_VerifyRecoverInit)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -671,7 +711,8 @@ CK_PKCS11_FUNCTION_INFO(C_VerifyRecoverInit)
 
 
 /* C_VerifyRecover verifies a signature in a single-part
- * operation, where the data is recovered from the signature. */
+ * operation, where the data is recovered from the signature.
+ */
 CK_PKCS11_FUNCTION_INFO(C_VerifyRecover)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -688,7 +729,8 @@ CK_PKCS11_FUNCTION_INFO(C_VerifyRecover)
 /* Dual-function cryptographic operations */
 
 /* C_DigestEncryptUpdate continues a multiple-part digesting
- * and encryption operation. */
+ * and encryption operation.
+ */
 CK_PKCS11_FUNCTION_INFO(C_DigestEncryptUpdate)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -702,7 +744,8 @@ CK_PKCS11_FUNCTION_INFO(C_DigestEncryptUpdate)
 
 
 /* C_DecryptDigestUpdate continues a multiple-part decryption and
- * digesting operation. */
+ * digesting operation.
+ */
 CK_PKCS11_FUNCTION_INFO(C_DecryptDigestUpdate)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -716,7 +759,8 @@ CK_PKCS11_FUNCTION_INFO(C_DecryptDigestUpdate)
 
 
 /* C_SignEncryptUpdate continues a multiple-part signing and
- * encryption operation. */
+ * encryption operation.
+ */
 CK_PKCS11_FUNCTION_INFO(C_SignEncryptUpdate)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -730,7 +774,8 @@ CK_PKCS11_FUNCTION_INFO(C_SignEncryptUpdate)
 
 
 /* C_DecryptVerifyUpdate continues a multiple-part decryption and
- * verify operation. */
+ * verify operation.
+ */
 CK_PKCS11_FUNCTION_INFO(C_DecryptVerifyUpdate)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -747,7 +792,8 @@ CK_PKCS11_FUNCTION_INFO(C_DecryptVerifyUpdate)
 /* Key management */
 
 /* C_GenerateKey generates a secret key, creating a new key
- * object. */
+ * object.
+ */
 CK_PKCS11_FUNCTION_INFO(C_GenerateKey)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -761,30 +807,19 @@ CK_PKCS11_FUNCTION_INFO(C_GenerateKey)
 
 
 /* C_GenerateKeyPair generates a public-key/private-key pair,
- * creating new key objects. */
+ * creating new key objects.
+ */
 CK_PKCS11_FUNCTION_INFO(C_GenerateKeyPair)
 #ifdef CK_NEED_ARG_LIST
 (
-  CK_SESSION_HANDLE    hSession,                    /* session
-                                                     * handle */
-  CK_MECHANISM_PTR     pMechanism,                  /* key-gen
-                                                     * mech. */
-  CK_ATTRIBUTE_PTR     pPublicKeyTemplate,          /* template
-                                                     * for pub.
-                                                     * key */
-  CK_ULONG             ulPublicKeyAttributeCount,   /* # pub.
-                                                     * attrs. */
-  CK_ATTRIBUTE_PTR     pPrivateKeyTemplate,         /* template
-                                                     * for priv.
-                                                     * key */
-  CK_ULONG             ulPrivateKeyAttributeCount,  /* # priv.
-                                                     * attrs. */
-  CK_OBJECT_HANDLE_PTR phPublicKey,                 /* gets pub.
-                                                     * key
-                                                     * handle */
-  CK_OBJECT_HANDLE_PTR phPrivateKey                 /* gets
-                                                     * priv. key
-                                                     * handle */
+  CK_SESSION_HANDLE    hSession,                    /* session handle */
+  CK_MECHANISM_PTR     pMechanism,                  /* key-gen mech. */
+  CK_ATTRIBUTE_PTR     pPublicKeyTemplate,          /* template for pub. key */
+  CK_ULONG             ulPublicKeyAttributeCount,   /* # pub. attrs. */
+  CK_ATTRIBUTE_PTR     pPrivateKeyTemplate,         /* template for priv. key */
+  CK_ULONG             ulPrivateKeyAttributeCount,  /* # priv.  attrs. */
+  CK_OBJECT_HANDLE_PTR phPublicKey,                 /* gets pub. key handle */
+  CK_OBJECT_HANDLE_PTR phPrivateKey                 /* gets priv. key handle */
 );
 #endif
 
@@ -804,7 +839,8 @@ CK_PKCS11_FUNCTION_INFO(C_WrapKey)
 
 
 /* C_UnwrapKey unwraps (decrypts) a wrapped key, creating a new
- * key object. */
+ * key object.
+ */
 CK_PKCS11_FUNCTION_INFO(C_UnwrapKey)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -821,7 +857,8 @@ CK_PKCS11_FUNCTION_INFO(C_UnwrapKey)
 
 
 /* C_DeriveKey derives a key from a base key, creating a new key
- * object. */
+ * object.
+ */
 CK_PKCS11_FUNCTION_INFO(C_DeriveKey)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -839,7 +876,8 @@ CK_PKCS11_FUNCTION_INFO(C_DeriveKey)
 /* Random number generation */
 
 /* C_SeedRandom mixes additional seed material into the token's
- * random number generator. */
+ * random number generator.
+ */
 CK_PKCS11_FUNCTION_INFO(C_SeedRandom)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -866,7 +904,8 @@ CK_PKCS11_FUNCTION_INFO(C_GenerateRandom)
 
 /* C_GetFunctionStatus is a legacy function; it obtains an
  * updated status of a function running in parallel with an
- * application. */
+ * application.
+ */
 CK_PKCS11_FUNCTION_INFO(C_GetFunctionStatus)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -876,7 +915,8 @@ CK_PKCS11_FUNCTION_INFO(C_GetFunctionStatus)
 
 
 /* C_CancelFunction is a legacy function; it cancels a function
- * running in parallel. */
+ * running in parallel.
+ */
 CK_PKCS11_FUNCTION_INFO(C_CancelFunction)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -885,11 +925,9 @@ CK_PKCS11_FUNCTION_INFO(C_CancelFunction)
 #endif
 
 
-
-/* Functions added in for Cryptoki Version 2.01 or later */
-
 /* C_WaitForSlotEvent waits for a slot event (token insertion,
- * removal, etc.) to occur. */
+ * removal, etc.) to occur.
+ */
 CK_PKCS11_FUNCTION_INFO(C_WaitForSlotEvent)
 #ifdef CK_NEED_ARG_LIST
 (
@@ -898,3 +936,4 @@ CK_PKCS11_FUNCTION_INFO(C_WaitForSlotEvent)
   CK_VOID_PTR pRserved   /* reserved.  Should be NULL_PTR */
 );
 #endif
+

--- a/vendor/github.com/miekg/pkcs11/pkcs11go.h
+++ b/vendor/github.com/miekg/pkcs11/pkcs11go.h
@@ -1,0 +1,83 @@
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+#define CK_PTR *
+#ifndef NULL_PTR
+#define NULL_PTR 0
+#endif
+#define CK_DEFINE_FUNCTION(returnType, name) returnType name
+#define CK_DECLARE_FUNCTION(returnType, name) returnType name
+#define CK_DECLARE_FUNCTION_POINTER(returnType, name) returnType (* name)
+#define CK_CALLBACK_FUNCTION(returnType, name) returnType (* name)
+
+#include <unistd.h>
+#ifdef REPACK_STRUCTURES
+# pragma pack(push, 1)
+# include "pkcs11.h"
+# pragma pack(pop)
+#else
+# include "pkcs11.h"
+#endif
+
+#ifdef REPACK_STRUCTURES
+
+// Go doesn't support structures with non-default packing, but PKCS#11 requires
+// pack(1) on Windows. Use structures with the same members as the CK_ ones but
+// default packing, and copy data between the two.
+
+typedef struct ckInfo {
+	CK_VERSION cryptokiVersion;
+	CK_UTF8CHAR manufacturerID[32];
+	CK_FLAGS flags;
+	CK_UTF8CHAR libraryDescription[32];
+	CK_VERSION libraryVersion;
+} ckInfo, *ckInfoPtr;
+
+typedef struct ckAttr {
+	CK_ATTRIBUTE_TYPE type;
+	CK_VOID_PTR pValue;
+	CK_ULONG ulValueLen;
+} ckAttr, *ckAttrPtr;
+
+typedef struct ckMech {
+	CK_MECHANISM_TYPE mechanism;
+	CK_VOID_PTR pParameter;
+	CK_ULONG ulParameterLen;
+} ckMech, *ckMechPtr;
+
+CK_RV attrsToC(CK_ATTRIBUTE_PTR *attrOut, ckAttrPtr attrIn, CK_ULONG count);
+void attrsFromC(ckAttrPtr attrOut, CK_ATTRIBUTE_PTR attrIn, CK_ULONG count);
+void mechToC(CK_MECHANISM_PTR mechOut, ckMechPtr mechIn);
+
+#define ATTR_TO_C(aout, ain, count, other) \
+	CK_ATTRIBUTE_PTR aout; \
+	{ \
+		CK_RV e = attrsToC(&aout, ain, count); \
+		if (e != CKR_OK ) { \
+			if (other != NULL) free(other); \
+			return e; \
+		} \
+	}
+#define ATTR_FREE(aout) free(aout)
+#define ATTR_FROM_C(aout, ain, count) attrsFromC(aout, ain, count)
+#define MECH_TO_C(mout, min) \
+	CK_MECHANISM mval, *mout = &mval; \
+	if (min != NULL) { mechToC(mout, min); \
+	} else { mout = NULL; }
+
+#else // REPACK_STRUCTURES
+
+// Dummy types and macros to avoid any unnecessary copying on UNIX
+
+typedef CK_INFO ckInfo, *ckInfoPtr;
+typedef CK_ATTRIBUTE ckAttr, *ckAttrPtr;
+typedef CK_MECHANISM ckMech, *ckMechPtr;
+
+#define ATTR_TO_C(aout, ain, count, other) CK_ATTRIBUTE_PTR aout = ain
+#define ATTR_FREE(aout)
+#define ATTR_FROM_C(aout, ain, count)
+#define MECH_TO_C(mout, min) CK_MECHANISM_PTR mout = min
+
+#endif // REPACK_STRUCTURES

--- a/vendor/github.com/miekg/pkcs11/pkcs11t.h
+++ b/vendor/github.com/miekg/pkcs11/pkcs11t.h
@@ -1,28 +1,33 @@
-/*
- * Copyright (C) OASIS Open 2014.  All rights reserved.
- * OASIS trademark, IPR and other policies apply.
- * http://www.oasis-open.org/policies-guidelines/ipr
+/* Copyright (c) OASIS Open 2016. All Rights Reserved./
+ * /Distributed under the terms of the OASIS IPR Policy,
+ * [http://www.oasis-open.org/policies-guidelines/ipr], AS-IS, WITHOUT ANY
+ * IMPLIED OR EXPRESS WARRANTY; there is no warranty of MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE or NONINFRINGEMENT of the rights of others.
+ */
+        
+/* Latest version of the specification:
+ * http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/pkcs11-base-v2.40.html
  */
 
 /* See top of pkcs11.h for information about the macros that
  * must be defined and the structure-packing conventions that
- * must be set before including this file. */
+ * must be set before including this file.
+ */
 
 #ifndef _PKCS11T_H_
 #define _PKCS11T_H_ 1
 
-#define CRYPTOKI_VERSION_MAJOR		2
-#define CRYPTOKI_VERSION_MINOR		40
-#define CRYPTOKI_VERSION_AMENDMENT	0
+#define CRYPTOKI_VERSION_MAJOR          2
+#define CRYPTOKI_VERSION_MINOR          40
+#define CRYPTOKI_VERSION_AMENDMENT      0
 
-#define CK_TRUE		1
-#define CK_FALSE	0
+#define CK_TRUE         1
+#define CK_FALSE        0
 
 #ifndef CK_DISABLE_TRUE_FALSE
 #ifndef FALSE
 #define FALSE CK_FALSE
 #endif
-
 #ifndef TRUE
 #define TRUE CK_TRUE
 #endif
@@ -51,8 +56,8 @@ typedef CK_ULONG          CK_FLAGS;
 
 
 /* some special values for certain CK_ULONG variables */
-#define CK_UNAVAILABLE_INFORMATION	(~0UL)
-#define CK_EFFECTIVELY_INFINITE		0UL
+#define CK_UNAVAILABLE_INFORMATION      (~0UL)
+#define CK_EFFECTIVELY_INFINITE         0UL
 
 
 typedef CK_BYTE     CK_PTR   CK_BYTE_PTR;
@@ -65,9 +70,10 @@ typedef void        CK_PTR   CK_VOID_PTR;
 typedef CK_VOID_PTR CK_PTR CK_VOID_PTR_PTR;
 
 
-/* The following value is always invalid if used as a session */
-/* handle or object handle */
-#define CK_INVALID_HANDLE	0UL
+/* The following value is always invalid if used as a session
+ * handle or object handle
+ */
+#define CK_INVALID_HANDLE       0UL
 
 
 typedef struct CK_VERSION {
@@ -79,12 +85,9 @@ typedef CK_VERSION CK_PTR CK_VERSION_PTR;
 
 
 typedef struct CK_INFO {
-  /* manufacturerID and libraryDecription have been changed from
-   * CK_CHAR to CK_UTF8CHAR for v2.10 */
   CK_VERSION    cryptokiVersion;     /* Cryptoki interface ver */
   CK_UTF8CHAR   manufacturerID[32];  /* blank padded */
   CK_FLAGS      flags;               /* must be zero */
-
   CK_UTF8CHAR   libraryDescription[32];  /* blank padded */
   CK_VERSION    libraryVersion;          /* version of library */
 } CK_INFO;
@@ -93,11 +96,11 @@ typedef CK_INFO CK_PTR    CK_INFO_PTR;
 
 
 /* CK_NOTIFICATION enumerates the types of notifications that
- * Cryptoki provides to an application */
+ * Cryptoki provides to an application
+ */
 typedef CK_ULONG CK_NOTIFICATION;
-#define CKN_SURRENDER		0UL
-#define CKN_OTP_CHANGED		1UL
-
+#define CKN_SURRENDER           0UL
+#define CKN_OTP_CHANGED         1UL
 
 typedef CK_ULONG          CK_SLOT_ID;
 
@@ -106,8 +109,6 @@ typedef CK_SLOT_ID CK_PTR CK_SLOT_ID_PTR;
 
 /* CK_SLOT_INFO provides information about a slot */
 typedef struct CK_SLOT_INFO {
-  /* slotDescription and manufacturerID have been changed from
-   * CK_CHAR to CK_UTF8CHAR for v2.10 */
   CK_UTF8CHAR   slotDescription[64];  /* blank padded */
   CK_UTF8CHAR   manufacturerID[32];   /* blank padded */
   CK_FLAGS      flags;
@@ -128,8 +129,6 @@ typedef CK_SLOT_INFO CK_PTR CK_SLOT_INFO_PTR;
 
 /* CK_TOKEN_INFO provides information about a token */
 typedef struct CK_TOKEN_INFO {
-  /* label, manufacturerID, and model have been changed from
-   * CK_CHAR to CK_UTF8CHAR for v2.10 */
   CK_UTF8CHAR   label[32];           /* blank padded */
   CK_UTF8CHAR   manufacturerID[32];  /* blank padded */
   CK_UTF8CHAR   model[16];           /* blank padded */
@@ -154,82 +153,88 @@ typedef struct CK_TOKEN_INFO {
 /* The flags parameter is defined as follows:
  *      Bit Flag                    Mask        Meaning
  */
-#define CKF_RNG                     0x00000001UL  /* has random #
-                                                   * generator */
-#define CKF_WRITE_PROTECTED         0x00000002UL  /* token is
-                                                   * write-
-                                                   * protected */
-#define CKF_LOGIN_REQUIRED          0x00000004UL  /* user must
-                                                   * login */
-#define CKF_USER_PIN_INITIALIZED    0x00000008UL  /* normal user's
-                                                   * PIN is set */
+#define CKF_RNG                     0x00000001UL  /* has random # generator */
+#define CKF_WRITE_PROTECTED         0x00000002UL  /* token is write-protected */
+#define CKF_LOGIN_REQUIRED          0x00000004UL  /* user must login */
+#define CKF_USER_PIN_INITIALIZED    0x00000008UL  /* normal user's PIN is set */
 
 /* CKF_RESTORE_KEY_NOT_NEEDED.  If it is set,
  * that means that *every* time the state of cryptographic
  * operations of a session is successfully saved, all keys
- * needed to continue those operations are stored in the state */
+ * needed to continue those operations are stored in the state
+ */
 #define CKF_RESTORE_KEY_NOT_NEEDED  0x00000020UL
 
 /* CKF_CLOCK_ON_TOKEN.  If it is set, that means
  * that the token has some sort of clock.  The time on that
- * clock is returned in the token info structure */
+ * clock is returned in the token info structure
+ */
 #define CKF_CLOCK_ON_TOKEN          0x00000040UL
 
 /* CKF_PROTECTED_AUTHENTICATION_PATH.  If it is
  * set, that means that there is some way for the user to login
- * without sending a PIN through the Cryptoki library itself */
+ * without sending a PIN through the Cryptoki library itself
+ */
 #define CKF_PROTECTED_AUTHENTICATION_PATH 0x00000100UL
 
 /* CKF_DUAL_CRYPTO_OPERATIONS.  If it is true,
  * that means that a single session with the token can perform
  * dual simultaneous cryptographic operations (digest and
  * encrypt; decrypt and digest; sign and encrypt; and decrypt
- * and sign) */
+ * and sign)
+ */
 #define CKF_DUAL_CRYPTO_OPERATIONS  0x00000200UL
 
 /* CKF_TOKEN_INITIALIZED. If it is true, the
  * token has been initialized using C_InitializeToken or an
  * equivalent mechanism outside the scope of PKCS #11.
  * Calling C_InitializeToken when this flag is set will cause
- * the token to be reinitialized. */
+ * the token to be reinitialized.
+ */
 #define CKF_TOKEN_INITIALIZED       0x00000400UL
 
 /* CKF_SECONDARY_AUTHENTICATION. If it is
  * true, the token supports secondary authentication for
- * private key objects. This flag is deprecated in v2.11 and
-   onwards. */
+ * private key objects.
+ */
 #define CKF_SECONDARY_AUTHENTICATION  0x00000800UL
 
 /* CKF_USER_PIN_COUNT_LOW. If it is true, an
  * incorrect user login PIN has been entered at least once
- * since the last successful authentication. */
+ * since the last successful authentication.
+ */
 #define CKF_USER_PIN_COUNT_LOW       0x00010000UL
 
 /* CKF_USER_PIN_FINAL_TRY. If it is true,
- * supplying an incorrect user PIN will it to become locked. */
+ * supplying an incorrect user PIN will it to become locked.
+ */
 #define CKF_USER_PIN_FINAL_TRY       0x00020000UL
 
 /* CKF_USER_PIN_LOCKED. If it is true, the
  * user PIN has been locked. User login to the token is not
- * possible. */
+ * possible.
+ */
 #define CKF_USER_PIN_LOCKED          0x00040000UL
 
 /* CKF_USER_PIN_TO_BE_CHANGED. If it is true,
  * the user PIN value is the default value set by token
  * initialization or manufacturing, or the PIN has been
- * expired by the card. */
+ * expired by the card.
+ */
 #define CKF_USER_PIN_TO_BE_CHANGED   0x00080000UL
 
 /* CKF_SO_PIN_COUNT_LOW. If it is true, an
  * incorrect SO login PIN has been entered at least once since
- * the last successful authentication. */
+ * the last successful authentication.
+ */
 #define CKF_SO_PIN_COUNT_LOW         0x00100000UL
 
 /* CKF_SO_PIN_FINAL_TRY. If it is true,
- * supplying an incorrect SO PIN will it to become locked. */
+ * supplying an incorrect SO PIN will it to become locked.
+ */
 #define CKF_SO_PIN_FINAL_TRY         0x00200000UL
 
-/* CKF_SO_PIN_LOCKED if new for v2.10. If it is true, the SO
+/* CKF_SO_PIN_LOCKED. If it is true, the SO
  * PIN has been locked. SO login to the token is not possible.
  */
 #define CKF_SO_PIN_LOCKED            0x00400000UL
@@ -237,7 +242,8 @@ typedef struct CK_TOKEN_INFO {
 /* CKF_SO_PIN_TO_BE_CHANGED. If it is true,
  * the SO PIN value is the default value set by token
  * initialization or manufacturing, or the PIN has been
- * expired by the card. */
+ * expired by the card.
+ */
 #define CKF_SO_PIN_TO_BE_CHANGED     0x00800000UL
 
 #define CKF_ERROR_STATE              0x01000000UL
@@ -246,7 +252,8 @@ typedef CK_TOKEN_INFO CK_PTR CK_TOKEN_INFO_PTR;
 
 
 /* CK_SESSION_HANDLE is a Cryptoki-assigned value that
- * identifies a session */
+ * identifies a session
+ */
 typedef CK_ULONG          CK_SESSION_HANDLE;
 
 typedef CK_SESSION_HANDLE CK_PTR CK_SESSION_HANDLE_PTR;
@@ -255,20 +262,19 @@ typedef CK_SESSION_HANDLE CK_PTR CK_SESSION_HANDLE_PTR;
 /* CK_USER_TYPE enumerates the types of Cryptoki users */
 typedef CK_ULONG          CK_USER_TYPE;
 /* Security Officer */
-#define CKU_SO			0UL
+#define CKU_SO                  0UL
 /* Normal user */
-#define CKU_USER		1UL
+#define CKU_USER                1UL
 /* Context specific */
-#define CKU_CONTEXT_SPECIFIC	2UL
+#define CKU_CONTEXT_SPECIFIC    2UL
 
 /* CK_STATE enumerates the session states */
 typedef CK_ULONG          CK_STATE;
-#define CKS_RO_PUBLIC_SESSION	0UL
-#define CKS_RO_USER_FUNCTIONS	1UL
-#define CKS_RW_PUBLIC_SESSION	2UL
-#define CKS_RW_USER_FUNCTIONS	3UL
-#define CKS_RW_SO_FUNCTIONS	4UL
-
+#define CKS_RO_PUBLIC_SESSION   0UL
+#define CKS_RO_USER_FUNCTIONS   1UL
+#define CKS_RW_PUBLIC_SESSION   2UL
+#define CKS_RW_USER_FUNCTIONS   3UL
+#define CKS_RW_SO_FUNCTIONS     4UL
 
 /* CK_SESSION_INFO provides information about a session */
 typedef struct CK_SESSION_INFO {
@@ -288,7 +294,8 @@ typedef CK_SESSION_INFO CK_PTR CK_SESSION_INFO_PTR;
 
 
 /* CK_OBJECT_HANDLE is a token-specific identifier for an
- * object  */
+ * object
+ */
 typedef CK_ULONG          CK_OBJECT_HANDLE;
 
 typedef CK_OBJECT_HANDLE CK_PTR CK_OBJECT_HANDLE_PTR;
@@ -296,7 +303,8 @@ typedef CK_OBJECT_HANDLE CK_PTR CK_OBJECT_HANDLE_PTR;
 
 /* CK_OBJECT_CLASS is a value that identifies the classes (or
  * types) of objects that Cryptoki recognizes.  It is defined
- * as follows: */
+ * as follows:
+ */
 typedef CK_ULONG          CK_OBJECT_CLASS;
 
 /* The following classes of objects are defined: */
@@ -314,9 +322,9 @@ typedef CK_ULONG          CK_OBJECT_CLASS;
 
 typedef CK_OBJECT_CLASS CK_PTR CK_OBJECT_CLASS_PTR;
 
-/* CK_HW_FEATURE_TYPE is a
- * value that identifies the hardware feature type of an object
- * with CK_OBJECT_CLASS equal to CKO_HW_FEATURE. */
+/* CK_HW_FEATURE_TYPE is a value that identifies the hardware feature type
+ * of an object with CK_OBJECT_CLASS equal to CKO_HW_FEATURE.
+ */
 typedef CK_ULONG          CK_HW_FEATURE_TYPE;
 
 /* The following hardware feature types are defined */
@@ -332,8 +340,7 @@ typedef CK_ULONG          CK_KEY_TYPE;
 #define CKK_RSA                 0x00000000UL
 #define CKK_DSA                 0x00000001UL
 #define CKK_DH                  0x00000002UL
-/* CKK_ECDSA is deprecated in v2.11, CKK_EC is preferred. */
-#define CKK_ECDSA               0x00000003UL
+#define CKK_ECDSA               0x00000003UL /* Deprecated */
 #define CKK_EC                  0x00000003UL
 #define CKK_X9_42_DH            0x00000004UL
 #define CKK_KEA                 0x00000005UL
@@ -345,8 +352,7 @@ typedef CK_ULONG          CK_KEY_TYPE;
 #define CKK_DES3                0x00000015UL
 #define CKK_CAST                0x00000016UL
 #define CKK_CAST3               0x00000017UL
-/* CKK_CAST5 is deprecated in v2.11, CKK_CAST128 is preferred. */
-#define CKK_CAST5               0x00000018UL
+#define CKK_CAST5               0x00000018UL /* Deprecated */
 #define CKK_CAST128             0x00000018UL
 #define CKK_RC5                 0x00000019UL
 #define CKK_IDEA                0x0000001AUL
@@ -363,37 +369,35 @@ typedef CK_ULONG          CK_KEY_TYPE;
 #define CKK_CAMELLIA            0x00000025UL
 #define CKK_ARIA                0x00000026UL
 
-/* new for v2.40 */
-#define CKK_SHA512_224_HMAC     0x00000027UL
-#define CKK_SHA512_256_HMAC     0x00000028UL
-#define CKK_SHA512_T_HMAC       0x00000029UL
+#define CKK_MD5_HMAC            0x00000027UL
+#define CKK_SHA_1_HMAC          0x00000028UL
+#define CKK_RIPEMD128_HMAC      0x00000029UL
+#define CKK_RIPEMD160_HMAC      0x0000002AUL
+#define CKK_SHA256_HMAC         0x0000002BUL
+#define CKK_SHA384_HMAC         0x0000002CUL
+#define CKK_SHA512_HMAC         0x0000002DUL
+#define CKK_SHA224_HMAC         0x0000002EUL
 
-#define CKK_SHA_1_HMAC          0x00000040UL
-#define CKK_SHA224_HMAC         0x00000041UL
-#define CKK_SHA256_HMAC         0x00000042UL
-#define CKK_SHA384_HMAC         0x00000043UL
-#define CKK_SHA512_HMAC         0x00000044UL
+#define CKK_SEED                0x0000002FUL
+#define CKK_GOSTR3410           0x00000030UL
+#define CKK_GOSTR3411           0x00000031UL
+#define CKK_GOST28147           0x00000032UL
 
-#define CKK_SEED                0x00000050UL
 
-#define CKK_GOSTR3410           0x00000060UL
-#define CKK_GOSTR3411           0x00000061UL
-#define CKK_GOST28147           0x00000062UL
 
-#define CKK_VENDOR_DEFINED	0x80000000UL
+#define CKK_VENDOR_DEFINED      0x80000000UL
 
 
 /* CK_CERTIFICATE_TYPE is a value that identifies a certificate
- * type */
+ * type
+ */
 typedef CK_ULONG          CK_CERTIFICATE_TYPE;
 
-/* new for v2.40 */
 #define CK_CERTIFICATE_CATEGORY_UNSPECIFIED     0UL
 #define CK_CERTIFICATE_CATEGORY_TOKEN_USER      1UL
 #define CK_CERTIFICATE_CATEGORY_AUTHORITY       2UL
 #define CK_CERTIFICATE_CATEGORY_OTHER_ENTITY    3UL
 
-/* new for v2.40 */
 #define CK_SECURITY_DOMAIN_UNSPECIFIED     0UL
 #define CK_SECURITY_DOMAIN_MANUFACTURER    1UL
 #define CK_SECURITY_DOMAIN_OPERATOR        2UL
@@ -401,30 +405,34 @@ typedef CK_ULONG          CK_CERTIFICATE_TYPE;
 
 
 /* The following certificate types are defined: */
-#define CKC_X_509		0x00000000UL
-#define CKC_X_509_ATTR_CERT	0x00000001UL
-#define CKC_WTLS		0x00000002UL
-#define CKC_VENDOR_DEFINED	0x80000000UL
+#define CKC_X_509               0x00000000UL
+#define CKC_X_509_ATTR_CERT     0x00000001UL
+#define CKC_WTLS                0x00000002UL
+#define CKC_VENDOR_DEFINED      0x80000000UL
 
 
 /* CK_ATTRIBUTE_TYPE is a value that identifies an attribute
- * type */
+ * type
+ */
 typedef CK_ULONG          CK_ATTRIBUTE_TYPE;
 
 /* The CKF_ARRAY_ATTRIBUTE flag identifies an attribute which
-   consists of an array of values. */
-#define CKF_ARRAY_ATTRIBUTE	0x40000000UL
+ * consists of an array of values.
+ */
+#define CKF_ARRAY_ATTRIBUTE     0x40000000UL
 
 /* The following OTP-related defines relate to the CKA_OTP_FORMAT attribute */
-#define CK_OTP_FORMAT_DECIMAL		0UL
-#define CK_OTP_FORMAT_HEXADECIMAL	1UL
-#define CK_OTP_FORMAT_ALPHANUMERIC	2UL
-#define CK_OTP_FORMAT_BINARY		3UL
+#define CK_OTP_FORMAT_DECIMAL           0UL
+#define CK_OTP_FORMAT_HEXADECIMAL       1UL
+#define CK_OTP_FORMAT_ALPHANUMERIC      2UL
+#define CK_OTP_FORMAT_BINARY            3UL
 
-/* The following OTP-related defines relate to the CKA_OTP_..._REQUIREMENT attributes */
-#define CK_OTP_PARAM_IGNORED		0UL
-#define CK_OTP_PARAM_OPTIONAL		1UL
-#define CK_OTP_PARAM_MANDATORY		2UL
+/* The following OTP-related defines relate to the CKA_OTP_..._REQUIREMENT
+ * attributes
+ */
+#define CK_OTP_PARAM_IGNORED            0UL
+#define CK_OTP_PARAM_OPTIONAL           1UL
+#define CK_OTP_PARAM_MANDATORY          2UL
 
 /* The following attribute types are defined: */
 #define CKA_CLASS              0x00000000UL
@@ -480,7 +488,6 @@ typedef CK_ULONG          CK_ATTRIBUTE_TYPE;
 
 #define CKA_PRIME_BITS         0x00000133UL
 #define CKA_SUBPRIME_BITS      0x00000134UL
-/* (To retain backwards-compatibility) */
 #define CKA_SUB_PRIME_BITS     CKA_SUBPRIME_BITS
 
 #define CKA_VALUE_BITS         0x00000160UL
@@ -494,18 +501,13 @@ typedef CK_ULONG          CK_ATTRIBUTE_TYPE;
 #define CKA_MODIFIABLE         0x00000170UL
 #define CKA_COPYABLE           0x00000171UL
 
-/* new for v2.40 */
 #define CKA_DESTROYABLE        0x00000172UL
 
-/* CKA_ECDSA_PARAMS is deprecated in v2.11,
- * CKA_EC_PARAMS is preferred. */
-#define CKA_ECDSA_PARAMS       0x00000180UL
+#define CKA_ECDSA_PARAMS       0x00000180UL /* Deprecated */
 #define CKA_EC_PARAMS          0x00000180UL
 
 #define CKA_EC_POINT           0x00000181UL
 
-/* CKA_SECONDARY_AUTH, CKA_AUTH_PIN_FLAGS,
- * are new for v2.10. Deprecated in v2.11 and onwards. */
 #define CKA_SECONDARY_AUTH     0x00000200UL /* Deprecated */
 #define CKA_AUTH_PIN_FLAGS     0x00000201UL /* Deprecated */
 
@@ -514,6 +516,7 @@ typedef CK_ULONG          CK_ATTRIBUTE_TYPE;
 #define CKA_WRAP_WITH_TRUSTED    0x00000210UL
 #define CKA_WRAP_TEMPLATE        (CKF_ARRAY_ATTRIBUTE|0x00000211UL)
 #define CKA_UNWRAP_TEMPLATE      (CKF_ARRAY_ATTRIBUTE|0x00000212UL)
+#define CKA_DERIVE_TEMPLATE      (CKF_ARRAY_ATTRIBUTE|0x00000213UL)
 
 #define CKA_OTP_FORMAT                0x00000220UL
 #define CKA_OTP_LENGTH                0x00000221UL
@@ -534,7 +537,7 @@ typedef CK_ULONG          CK_ATTRIBUTE_TYPE;
 #define CKA_GOSTR3411_PARAMS            0x00000251UL
 #define CKA_GOST28147_PARAMS            0x00000252UL
 
-#define CKA_HW_FEATURE_TYPE	        0x00000300UL
+#define CKA_HW_FEATURE_TYPE             0x00000300UL
 #define CKA_RESET_ON_INIT               0x00000301UL
 #define CKA_HAS_RESET                   0x00000302UL
 
@@ -557,7 +560,8 @@ typedef CK_ULONG          CK_ATTRIBUTE_TYPE;
 #define CKA_VENDOR_DEFINED              0x80000000UL
 
 /* CK_ATTRIBUTE is a structure that includes the type, length
- * and value of an attribute */
+ * and value of an attribute
+ */
 typedef struct CK_ATTRIBUTE {
   CK_ATTRIBUTE_TYPE type;
   CK_VOID_PTR       pValue;
@@ -565,7 +569,6 @@ typedef struct CK_ATTRIBUTE {
 } CK_ATTRIBUTE;
 
 typedef CK_ATTRIBUTE CK_PTR CK_ATTRIBUTE_PTR;
-
 
 /* CK_DATE is a structure that defines a date */
 typedef struct CK_DATE{
@@ -576,7 +579,8 @@ typedef struct CK_DATE{
 
 
 /* CK_MECHANISM_TYPE is a value that identifies a mechanism
- * type */
+ * type
+ */
 typedef CK_ULONG          CK_MECHANISM_TYPE;
 
 /* the following mechanism types are defined: */
@@ -599,15 +603,13 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_RSA_PKCS_PSS               0x0000000DUL
 #define CKM_SHA1_RSA_PKCS_PSS          0x0000000EUL
 
-/* new for v2.40 */
 #define CKM_DSA_KEY_PAIR_GEN           0x00000010UL
 #define CKM_DSA                        0x00000011UL
 #define CKM_DSA_SHA1                   0x00000012UL
-#define CKM_DSA_FIPS_G_GEN             0x00000013UL
-#define CKM_DSA_SHA224                 0x00000014UL
-#define CKM_DSA_SHA256                 0x00000015UL
-#define CKM_DSA_SHA384                 0x00000016UL
-#define CKM_DSA_SHA512                 0x00000017UL
+#define CKM_DSA_SHA224                 0x00000013UL
+#define CKM_DSA_SHA256                 0x00000014UL
+#define CKM_DSA_SHA384                 0x00000015UL
+#define CKM_DSA_SHA512                 0x00000016UL
 
 #define CKM_DH_PKCS_KEY_PAIR_GEN       0x00000020UL
 #define CKM_DH_PKCS_DERIVE             0x00000021UL
@@ -627,7 +629,6 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_SHA224_RSA_PKCS            0x00000046UL
 #define CKM_SHA224_RSA_PKCS_PSS        0x00000047UL
 
-/* new for v2.40 */
 #define CKM_SHA512_224                 0x00000048UL
 #define CKM_SHA512_224_HMAC            0x00000049UL
 #define CKM_SHA512_224_HMAC_GENERAL    0x0000004AUL
@@ -723,7 +724,6 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_ACTI                       0x000002A0UL
 #define CKM_ACTI_KEY_GEN               0x000002A1UL
 
-/* new for v2.40 */
 #define CKM_CAST_KEY_GEN               0x00000300UL
 #define CKM_CAST_ECB                   0x00000301UL
 #define CKM_CAST_CBC                   0x00000302UL
@@ -741,13 +741,13 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_CAST128_KEY_GEN            0x00000320UL
 #define CKM_CAST5_ECB                  0x00000321UL
 #define CKM_CAST128_ECB                0x00000321UL
-#define CKM_CAST5_CBC                  0x00000322UL
+#define CKM_CAST5_CBC                  0x00000322UL /* Deprecated */
 #define CKM_CAST128_CBC                0x00000322UL
-#define CKM_CAST5_MAC                  0x00000323UL
+#define CKM_CAST5_MAC                  0x00000323UL /* Deprecated */
 #define CKM_CAST128_MAC                0x00000323UL
-#define CKM_CAST5_MAC_GENERAL          0x00000324UL
+#define CKM_CAST5_MAC_GENERAL          0x00000324UL /* Deprecated */
 #define CKM_CAST128_MAC_GENERAL        0x00000324UL
-#define CKM_CAST5_CBC_PAD              0x00000325UL
+#define CKM_CAST5_CBC_PAD              0x00000325UL /* Deprecated */
 #define CKM_CAST128_CBC_PAD            0x00000325UL
 #define CKM_RC5_KEY_GEN                0x00000330UL
 #define CKM_RC5_ECB                    0x00000331UL
@@ -790,14 +790,13 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_SHA512_KEY_DERIVATION      0x00000395UL
 #define CKM_SHA224_KEY_DERIVATION      0x00000396UL
 
-/* new for v2.40 */
 #define CKM_PBE_MD2_DES_CBC            0x000003A0UL
 #define CKM_PBE_MD5_DES_CBC            0x000003A1UL
 #define CKM_PBE_MD5_CAST_CBC           0x000003A2UL
 #define CKM_PBE_MD5_CAST3_CBC          0x000003A3UL
-#define CKM_PBE_MD5_CAST5_CBC          0x000003A4UL
+#define CKM_PBE_MD5_CAST5_CBC          0x000003A4UL /* Deprecated */
 #define CKM_PBE_MD5_CAST128_CBC        0x000003A4UL
-#define CKM_PBE_SHA1_CAST5_CBC         0x000003A5UL
+#define CKM_PBE_SHA1_CAST5_CBC         0x000003A5UL /* Deprecated */
 #define CKM_PBE_SHA1_CAST128_CBC       0x000003A5UL
 #define CKM_PBE_SHA1_RC4_128           0x000003A6UL
 #define CKM_PBE_SHA1_RC4_40            0x000003A7UL
@@ -817,7 +816,6 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_WTLS_SERVER_KEY_AND_MAC_DERIVE  0x000003D4UL
 #define CKM_WTLS_CLIENT_KEY_AND_MAC_DERIVE  0x000003D5UL
 
-/* new for v2.40 */
 #define CKM_TLS10_MAC_SERVER                0x000003D6UL
 #define CKM_TLS10_MAC_CLIENT                0x000003D7UL
 #define CKM_TLS12_MAC                       0x000003D8UL
@@ -833,10 +831,9 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_KEY_WRAP_SET_OAEP          0x00000401UL
 
 #define CKM_CMS_SIG                    0x00000500UL
-/* new for v2.40 */
-#define CKM_KIP_DERIVE	               0x00000510UL
-#define CKM_KIP_WRAP	               0x00000511UL
-#define CKM_KIP_MAC	               0x00000512UL
+#define CKM_KIP_DERIVE                 0x00000510UL
+#define CKM_KIP_WRAP                   0x00000511UL
+#define CKM_KIP_MAC                    0x00000512UL
 
 #define CKM_CAMELLIA_KEY_GEN           0x00000550UL
 #define CKM_CAMELLIA_ECB               0x00000551UL
@@ -889,19 +886,20 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_BATON_SHUFFLE              0x00001035UL
 #define CKM_BATON_WRAP                 0x00001036UL
 
-/* CKM_ECDSA_KEY_PAIR_GEN is deprecated in v2.11,
- * CKM_EC_KEY_PAIR_GEN is preferred */
-#define CKM_ECDSA_KEY_PAIR_GEN         0x00001040UL
+#define CKM_ECDSA_KEY_PAIR_GEN         0x00001040UL /* Deprecated */
 #define CKM_EC_KEY_PAIR_GEN            0x00001040UL
 
 #define CKM_ECDSA                      0x00001041UL
 #define CKM_ECDSA_SHA1                 0x00001042UL
+#define CKM_ECDSA_SHA224               0x00001043UL
+#define CKM_ECDSA_SHA256               0x00001044UL
+#define CKM_ECDSA_SHA384               0x00001045UL
+#define CKM_ECDSA_SHA512               0x00001046UL
 
 #define CKM_ECDH1_DERIVE               0x00001050UL
 #define CKM_ECDH1_COFACTOR_DERIVE      0x00001051UL
 #define CKM_ECMQV_DERIVE               0x00001052UL
 
-/* new for v2.40 */
 #define CKM_ECDH_AES_KEY_WRAP          0x00001053UL
 #define CKM_RSA_AES_KEY_WRAP           0x00001054UL
 
@@ -922,11 +920,10 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_AES_CTR                    0x00001086UL
 #define CKM_AES_GCM                    0x00001087UL
 #define CKM_AES_CCM                    0x00001088UL
-#define CKM_AES_CMAC_GENERAL           0x00001089UL
+#define CKM_AES_CTS                    0x00001089UL
 #define CKM_AES_CMAC                   0x0000108AUL
-#define CKM_AES_CTS                    0x0000108BUL
+#define CKM_AES_CMAC_GENERAL           0x0000108BUL
 
-/* new for v2.40 */
 #define CKM_AES_XCBC_MAC               0x0000108CUL
 #define CKM_AES_XCBC_MAC_96            0x0000108DUL
 #define CKM_AES_GMAC                   0x0000108EUL
@@ -969,10 +966,9 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_AES_CFB8                   0x00002106UL
 #define CKM_AES_CFB128                 0x00002107UL
 
-/* new for v2.40 */
 #define CKM_AES_CFB1                   0x00002108UL
-#define CKM_AES_KEY_WRAP               0x00002109UL
-#define CKM_AES_KEY_WRAP_PAD           0x0000210AUL
+#define CKM_AES_KEY_WRAP               0x00002109UL     /* WAS: 0x00001090 */
+#define CKM_AES_KEY_WRAP_PAD           0x0000210AUL     /* WAS: 0x00001091 */
 
 #define CKM_RSA_PKCS_TPM_1_1           0x00004001UL
 #define CKM_RSA_PKCS_OAEP_TPM_1_1      0x00004002UL
@@ -983,7 +979,8 @@ typedef CK_MECHANISM_TYPE CK_PTR CK_MECHANISM_TYPE_PTR;
 
 
 /* CK_MECHANISM is a structure that specifies a particular
- * mechanism  */
+ * mechanism
+ */
 typedef struct CK_MECHANISM {
   CK_MECHANISM_TYPE mechanism;
   CK_VOID_PTR       pParameter;
@@ -994,7 +991,8 @@ typedef CK_MECHANISM CK_PTR CK_MECHANISM_PTR;
 
 
 /* CK_MECHANISM_INFO provides information about a particular
- * mechanism */
+ * mechanism
+ */
 typedef struct CK_MECHANISM_INFO {
     CK_ULONG    ulMinKeySize;
     CK_ULONG    ulMaxKeySize;
@@ -1020,7 +1018,8 @@ typedef struct CK_MECHANISM_INFO {
 #define CKF_DERIVE             0x00080000UL
 
 /* Describe a token's EC capabilities not available in mechanism
- * information. */
+ * information.
+ */
 #define CKF_EC_F_P             0x00100000UL
 #define CKF_EC_F_2M            0x00200000UL
 #define CKF_EC_ECPARAMETERS    0x00400000UL
@@ -1028,21 +1027,19 @@ typedef struct CK_MECHANISM_INFO {
 #define CKF_EC_UNCOMPRESS      0x01000000UL
 #define CKF_EC_COMPRESS        0x02000000UL
 
-#define CKF_EXTENSION          0x80000000UL /* FALSE for this version */
+#define CKF_EXTENSION          0x80000000UL
 
 typedef CK_MECHANISM_INFO CK_PTR CK_MECHANISM_INFO_PTR;
 
-
 /* CK_RV is a value that identifies the return value of a
- * Cryptoki function */
+ * Cryptoki function
+ */
 typedef CK_ULONG          CK_RV;
 
 #define CKR_OK                                0x00000000UL
 #define CKR_CANCEL                            0x00000001UL
 #define CKR_HOST_MEMORY                       0x00000002UL
 #define CKR_SLOT_ID_INVALID                   0x00000003UL
-
-/* CKR_FLAGS_INVALID was removed for v2.0 */
 
 #define CKR_GENERAL_ERROR                     0x00000005UL
 #define CKR_FUNCTION_FAILED                   0x00000006UL
@@ -1057,7 +1054,6 @@ typedef CK_ULONG          CK_RV;
 #define CKR_ATTRIBUTE_TYPE_INVALID            0x00000012UL
 #define CKR_ATTRIBUTE_VALUE_INVALID           0x00000013UL
 
-/* new for v2.40 */
 #define CKR_ACTION_PROHIBITED                 0x0000001BUL
 
 #define CKR_DATA_INVALID                      0x00000020UL
@@ -1074,8 +1070,6 @@ typedef CK_ULONG          CK_RV;
 
 #define CKR_KEY_HANDLE_INVALID                0x00000060UL
 
-/* CKR_KEY_SENSITIVE was removed for v2.0 */
-
 #define CKR_KEY_SIZE_RANGE                    0x00000062UL
 #define CKR_KEY_TYPE_INCONSISTENT             0x00000063UL
 
@@ -1090,8 +1084,6 @@ typedef CK_ULONG          CK_RV;
 #define CKR_MECHANISM_INVALID                 0x00000070UL
 #define CKR_MECHANISM_PARAM_INVALID           0x00000071UL
 
-/* CKR_OBJECT_CLASS_INCONSISTENT and CKR_OBJECT_CLASS_INVALID
- * were removed for v2.0 */
 #define CKR_OBJECT_HANDLE_INVALID             0x00000082UL
 #define CKR_OPERATION_ACTIVE                  0x00000090UL
 #define CKR_OPERATION_NOT_INITIALIZED         0x00000091UL
@@ -1141,7 +1133,6 @@ typedef CK_ULONG          CK_RV;
 
 #define CKR_DOMAIN_PARAMS_INVALID             0x00000130UL
 
-/* new for v2.40 */
 #define CKR_CURVE_NOT_SUPPORTED               0x00000140UL
 
 #define CKR_BUFFER_TOO_SMALL                  0x00000150UL
@@ -1157,11 +1148,11 @@ typedef CK_ULONG          CK_RV;
 #define CKR_NEW_PIN_MODE                      0x000001B0UL
 #define CKR_NEXT_OTP                          0x000001B1UL
 
-#define CKR_EXCEEDED_MAX_ITERATIONS           0x000001C0UL
-#define CKR_FIPS_SELF_TEST_FAILED             0x000001C1UL
-#define CKR_LIBRARY_LOAD_FAILED               0x000001C2UL
-#define CKR_PIN_TOO_WEAK                      0x000001C3UL
-#define CKR_PUBLIC_KEY_INVALID                0x000001C4UL
+#define CKR_EXCEEDED_MAX_ITERATIONS           0x000001B5UL
+#define CKR_FIPS_SELF_TEST_FAILED             0x000001B6UL
+#define CKR_LIBRARY_LOAD_FAILED               0x000001B7UL
+#define CKR_PIN_TOO_WEAK                      0x000001B8UL
+#define CKR_PUBLIC_KEY_INVALID                0x000001B9UL
 
 #define CKR_FUNCTION_REJECTED                 0x00000200UL
 
@@ -1178,7 +1169,8 @@ typedef CK_CALLBACK_FUNCTION(CK_RV, CK_NOTIFY)(
 
 /* CK_FUNCTION_LIST is a structure holding a Cryptoki spec
  * version and pointers of appropriate types to all the
- * Cryptoki functions */
+ * Cryptoki functions
+ */
 typedef struct CK_FUNCTION_LIST CK_FUNCTION_LIST;
 
 typedef CK_FUNCTION_LIST CK_PTR CK_FUNCTION_LIST_PTR;
@@ -1187,14 +1179,16 @@ typedef CK_FUNCTION_LIST_PTR CK_PTR CK_FUNCTION_LIST_PTR_PTR;
 
 
 /* CK_CREATEMUTEX is an application callback for creating a
- * mutex object */
+ * mutex object
+ */
 typedef CK_CALLBACK_FUNCTION(CK_RV, CK_CREATEMUTEX)(
   CK_VOID_PTR_PTR ppMutex  /* location to receive ptr to mutex */
 );
 
 
 /* CK_DESTROYMUTEX is an application callback for destroying a
- * mutex object */
+ * mutex object
+ */
 typedef CK_CALLBACK_FUNCTION(CK_RV, CK_DESTROYMUTEX)(
   CK_VOID_PTR pMutex  /* pointer to mutex */
 );
@@ -1207,14 +1201,16 @@ typedef CK_CALLBACK_FUNCTION(CK_RV, CK_LOCKMUTEX)(
 
 
 /* CK_UNLOCKMUTEX is an application callback for unlocking a
- * mutex */
+ * mutex
+ */
 typedef CK_CALLBACK_FUNCTION(CK_RV, CK_UNLOCKMUTEX)(
   CK_VOID_PTR pMutex  /* pointer to mutex */
 );
 
 
 /* CK_C_INITIALIZE_ARGS provides the optional arguments to
- * C_Initialize */
+ * C_Initialize
+ */
 typedef struct CK_C_INITIALIZE_ARGS {
   CK_CREATEMUTEX CreateMutex;
   CK_DESTROYMUTEX DestroyMutex;
@@ -1238,11 +1234,11 @@ typedef CK_C_INITIALIZE_ARGS CK_PTR CK_C_INITIALIZE_ARGS_PTR;
 /* CKF_DONT_BLOCK is for the function C_WaitForSlotEvent */
 #define CKF_DONT_BLOCK     1
 
-/*
- * CK_RSA_PKCS_MGF_TYPE  is used to indicate the Message
+/* CK_RSA_PKCS_MGF_TYPE  is used to indicate the Message
  * Generation Function (MGF) applied to a message block when
  * formatting a message block for the PKCS #1 OAEP encryption
- * scheme. */
+ * scheme.
+ */
 typedef CK_ULONG CK_RSA_PKCS_MGF_TYPE;
 
 typedef CK_RSA_PKCS_MGF_TYPE CK_PTR CK_RSA_PKCS_MGF_TYPE_PTR;
@@ -1254,10 +1250,10 @@ typedef CK_RSA_PKCS_MGF_TYPE CK_PTR CK_RSA_PKCS_MGF_TYPE_PTR;
 #define CKG_MGF1_SHA512       0x00000004UL
 #define CKG_MGF1_SHA224       0x00000005UL
 
-/*
- * CK_RSA_PKCS_OAEP_SOURCE_TYPE  is used to indicate the source
+/* CK_RSA_PKCS_OAEP_SOURCE_TYPE  is used to indicate the source
  * of the encoding parameter when formatting a message block
- * for the PKCS #1 OAEP encryption scheme. */
+ * for the PKCS #1 OAEP encryption scheme.
+ */
 typedef CK_ULONG CK_RSA_PKCS_OAEP_SOURCE_TYPE;
 
 typedef CK_RSA_PKCS_OAEP_SOURCE_TYPE CK_PTR CK_RSA_PKCS_OAEP_SOURCE_TYPE_PTR;
@@ -1265,9 +1261,9 @@ typedef CK_RSA_PKCS_OAEP_SOURCE_TYPE CK_PTR CK_RSA_PKCS_OAEP_SOURCE_TYPE_PTR;
 /* The following encoding parameter sources are defined */
 #define CKZ_DATA_SPECIFIED    0x00000001UL
 
-/*
- * CK_RSA_PKCS_OAEP_PARAMS provides the parameters to the
- * CKM_RSA_PKCS_OAEP mechanism. */
+/* CK_RSA_PKCS_OAEP_PARAMS provides the parameters to the
+ * CKM_RSA_PKCS_OAEP mechanism.
+ */
 typedef struct CK_RSA_PKCS_OAEP_PARAMS {
         CK_MECHANISM_TYPE hashAlg;
         CK_RSA_PKCS_MGF_TYPE mgf;
@@ -1278,9 +1274,9 @@ typedef struct CK_RSA_PKCS_OAEP_PARAMS {
 
 typedef CK_RSA_PKCS_OAEP_PARAMS CK_PTR CK_RSA_PKCS_OAEP_PARAMS_PTR;
 
-/*
- * CK_RSA_PKCS_PSS_PARAMS provides the parameters to the
- * CKM_RSA_PKCS_PSS mechanism(s). */
+/* CK_RSA_PKCS_PSS_PARAMS provides the parameters to the
+ * CKM_RSA_PKCS_PSS mechanism(s).
+ */
 typedef struct CK_RSA_PKCS_PSS_PARAMS {
         CK_MECHANISM_TYPE    hashAlg;
         CK_RSA_PKCS_MGF_TYPE mgf;
@@ -1294,6 +1290,7 @@ typedef CK_ULONG CK_EC_KDF_TYPE;
 /* The following EC Key Derivation Functions are defined */
 #define CKD_NULL                 0x00000001UL
 #define CKD_SHA1_KDF             0x00000002UL
+
 /* The following X9.42 DH key derivation functions are defined */
 #define CKD_SHA1_KDF_ASN1        0x00000003UL
 #define CKD_SHA1_KDF_CONCATENATE 0x00000004UL
@@ -1304,8 +1301,7 @@ typedef CK_ULONG CK_EC_KDF_TYPE;
 #define CKD_CPDIVERSIFY_KDF      0x00000009UL
 
 
-/*
- * CK_ECDH1_DERIVE_PARAMS provides the parameters to the
+/* CK_ECDH1_DERIVE_PARAMS provides the parameters to the
  * CKM_ECDH1_DERIVE and CKM_ECDH1_COFACTOR_DERIVE mechanisms,
  * where each party contributes one key pair.
  */
@@ -1318,6 +1314,24 @@ typedef struct CK_ECDH1_DERIVE_PARAMS {
 } CK_ECDH1_DERIVE_PARAMS;
 
 typedef CK_ECDH1_DERIVE_PARAMS CK_PTR CK_ECDH1_DERIVE_PARAMS_PTR;
+
+/*
+ * CK_ECDH2_DERIVE_PARAMS provides the parameters to the
+ * CKM_ECMQV_DERIVE mechanism, where each party contributes two key pairs.
+ */
+typedef struct CK_ECDH2_DERIVE_PARAMS {
+  CK_EC_KDF_TYPE kdf;
+  CK_ULONG ulSharedDataLen;
+  CK_BYTE_PTR pSharedData;
+  CK_ULONG ulPublicDataLen;
+  CK_BYTE_PTR pPublicData;
+  CK_ULONG ulPrivateDataLen;
+  CK_OBJECT_HANDLE hPrivateData;
+  CK_ULONG ulPublicDataLen2;
+  CK_BYTE_PTR pPublicData2;
+} CK_ECDH2_DERIVE_PARAMS;
+
+typedef CK_ECDH2_DERIVE_PARAMS CK_PTR CK_ECDH2_DERIVE_PARAMS_PTR;
 
 typedef struct CK_ECMQV_DERIVE_PARAMS {
   CK_EC_KDF_TYPE kdf;
@@ -1335,14 +1349,15 @@ typedef struct CK_ECMQV_DERIVE_PARAMS {
 typedef CK_ECMQV_DERIVE_PARAMS CK_PTR CK_ECMQV_DERIVE_PARAMS_PTR;
 
 /* Typedefs and defines for the CKM_X9_42_DH_KEY_PAIR_GEN and the
- * CKM_X9_42_DH_PARAMETER_GEN mechanisms */
+ * CKM_X9_42_DH_PARAMETER_GEN mechanisms
+ */
 typedef CK_ULONG CK_X9_42_DH_KDF_TYPE;
 typedef CK_X9_42_DH_KDF_TYPE CK_PTR CK_X9_42_DH_KDF_TYPE_PTR;
 
-/*
- * CK_X9_42_DH1_DERIVE_PARAMS provides the parameters to the
+/* CK_X9_42_DH1_DERIVE_PARAMS provides the parameters to the
  * CKM_X9_42_DH_DERIVE key derivation mechanism, where each party
- * contributes one key pair */
+ * contributes one key pair
+ */
 typedef struct CK_X9_42_DH1_DERIVE_PARAMS {
   CK_X9_42_DH_KDF_TYPE kdf;
   CK_ULONG ulOtherInfoLen;
@@ -1353,10 +1368,10 @@ typedef struct CK_X9_42_DH1_DERIVE_PARAMS {
 
 typedef struct CK_X9_42_DH1_DERIVE_PARAMS CK_PTR CK_X9_42_DH1_DERIVE_PARAMS_PTR;
 
-/*
- * CK_X9_42_DH2_DERIVE_PARAMS provides the parameters to the
+/* CK_X9_42_DH2_DERIVE_PARAMS provides the parameters to the
  * CKM_X9_42_DH_HYBRID_DERIVE and CKM_X9_42_MQV_DERIVE key derivation
- * mechanisms, where each party contributes two key pairs */
+ * mechanisms, where each party contributes two key pairs
+ */
 typedef struct CK_X9_42_DH2_DERIVE_PARAMS {
   CK_X9_42_DH_KDF_TYPE kdf;
   CK_ULONG ulOtherInfoLen;
@@ -1387,7 +1402,8 @@ typedef struct CK_X9_42_MQV_DERIVE_PARAMS {
 typedef CK_X9_42_MQV_DERIVE_PARAMS CK_PTR CK_X9_42_MQV_DERIVE_PARAMS_PTR;
 
 /* CK_KEA_DERIVE_PARAMS provides the parameters to the
- * CKM_KEA_DERIVE mechanism */
+ * CKM_KEA_DERIVE mechanism
+ */
 typedef struct CK_KEA_DERIVE_PARAMS {
   CK_BBOOL      isSender;
   CK_ULONG      ulRandomLen;
@@ -1402,17 +1418,18 @@ typedef CK_KEA_DERIVE_PARAMS CK_PTR CK_KEA_DERIVE_PARAMS_PTR;
 
 /* CK_RC2_PARAMS provides the parameters to the CKM_RC2_ECB and
  * CKM_RC2_MAC mechanisms.  An instance of CK_RC2_PARAMS just
- * holds the effective keysize */
+ * holds the effective keysize
+ */
 typedef CK_ULONG          CK_RC2_PARAMS;
 
 typedef CK_RC2_PARAMS CK_PTR CK_RC2_PARAMS_PTR;
 
 
 /* CK_RC2_CBC_PARAMS provides the parameters to the CKM_RC2_CBC
- * mechanism */
+ * mechanism
+ */
 typedef struct CK_RC2_CBC_PARAMS {
   CK_ULONG      ulEffectiveBits;  /* effective bits (1-1024) */
-
   CK_BYTE       iv[8];            /* IV for CBC mode */
 } CK_RC2_CBC_PARAMS;
 
@@ -1420,7 +1437,8 @@ typedef CK_RC2_CBC_PARAMS CK_PTR CK_RC2_CBC_PARAMS_PTR;
 
 
 /* CK_RC2_MAC_GENERAL_PARAMS provides the parameters for the
- * CKM_RC2_MAC_GENERAL mechanism */
+ * CKM_RC2_MAC_GENERAL mechanism
+ */
 typedef struct CK_RC2_MAC_GENERAL_PARAMS {
   CK_ULONG      ulEffectiveBits;  /* effective bits (1-1024) */
   CK_ULONG      ulMacLength;      /* Length of MAC in bytes */
@@ -1431,7 +1449,8 @@ typedef CK_RC2_MAC_GENERAL_PARAMS CK_PTR \
 
 
 /* CK_RC5_PARAMS provides the parameters to the CKM_RC5_ECB and
- * CKM_RC5_MAC mechanisms */
+ * CKM_RC5_MAC mechanisms
+ */
 typedef struct CK_RC5_PARAMS {
   CK_ULONG      ulWordsize;  /* wordsize in bits */
   CK_ULONG      ulRounds;    /* number of rounds */
@@ -1441,7 +1460,8 @@ typedef CK_RC5_PARAMS CK_PTR CK_RC5_PARAMS_PTR;
 
 
 /* CK_RC5_CBC_PARAMS provides the parameters to the CKM_RC5_CBC
- * mechanism */
+ * mechanism
+ */
 typedef struct CK_RC5_CBC_PARAMS {
   CK_ULONG      ulWordsize;  /* wordsize in bits */
   CK_ULONG      ulRounds;    /* number of rounds */
@@ -1453,7 +1473,8 @@ typedef CK_RC5_CBC_PARAMS CK_PTR CK_RC5_CBC_PARAMS_PTR;
 
 
 /* CK_RC5_MAC_GENERAL_PARAMS provides the parameters for the
- * CKM_RC5_MAC_GENERAL mechanism */
+ * CKM_RC5_MAC_GENERAL mechanism
+ */
 typedef struct CK_RC5_MAC_GENERAL_PARAMS {
   CK_ULONG      ulWordsize;   /* wordsize in bits */
   CK_ULONG      ulRounds;     /* number of rounds */
@@ -1463,10 +1484,10 @@ typedef struct CK_RC5_MAC_GENERAL_PARAMS {
 typedef CK_RC5_MAC_GENERAL_PARAMS CK_PTR \
   CK_RC5_MAC_GENERAL_PARAMS_PTR;
 
-
 /* CK_MAC_GENERAL_PARAMS provides the parameters to most block
  * ciphers' MAC_GENERAL mechanisms.  Its value is the length of
- * the MAC */
+ * the MAC
+ */
 typedef CK_ULONG          CK_MAC_GENERAL_PARAMS;
 
 typedef CK_MAC_GENERAL_PARAMS CK_PTR CK_MAC_GENERAL_PARAMS_PTR;
@@ -1488,7 +1509,8 @@ typedef struct CK_AES_CBC_ENCRYPT_DATA_PARAMS {
 typedef CK_AES_CBC_ENCRYPT_DATA_PARAMS CK_PTR CK_AES_CBC_ENCRYPT_DATA_PARAMS_PTR;
 
 /* CK_SKIPJACK_PRIVATE_WRAP_PARAMS provides the parameters to the
- * CKM_SKIPJACK_PRIVATE_WRAP mechanism */
+ * CKM_SKIPJACK_PRIVATE_WRAP mechanism
+ */
 typedef struct CK_SKIPJACK_PRIVATE_WRAP_PARAMS {
   CK_ULONG      ulPasswordLen;
   CK_BYTE_PTR   pPassword;
@@ -1508,7 +1530,8 @@ typedef CK_SKIPJACK_PRIVATE_WRAP_PARAMS CK_PTR \
 
 
 /* CK_SKIPJACK_RELAYX_PARAMS provides the parameters to the
- * CKM_SKIPJACK_RELAYX mechanism */
+ * CKM_SKIPJACK_RELAYX mechanism
+ */
 typedef struct CK_SKIPJACK_RELAYX_PARAMS {
   CK_ULONG      ulOldWrappedXLen;
   CK_BYTE_PTR   pOldWrappedX;
@@ -1543,16 +1566,15 @@ typedef CK_PBE_PARAMS CK_PTR CK_PBE_PARAMS_PTR;
 
 
 /* CK_KEY_WRAP_SET_OAEP_PARAMS provides the parameters to the
- * CKM_KEY_WRAP_SET_OAEP mechanism */
+ * CKM_KEY_WRAP_SET_OAEP mechanism
+ */
 typedef struct CK_KEY_WRAP_SET_OAEP_PARAMS {
   CK_BYTE       bBC;     /* block contents byte */
   CK_BYTE_PTR   pX;      /* extra data */
   CK_ULONG      ulXLen;  /* length of extra data in bytes */
 } CK_KEY_WRAP_SET_OAEP_PARAMS;
 
-typedef CK_KEY_WRAP_SET_OAEP_PARAMS CK_PTR \
-  CK_KEY_WRAP_SET_OAEP_PARAMS_PTR;
-
+typedef CK_KEY_WRAP_SET_OAEP_PARAMS CK_PTR CK_KEY_WRAP_SET_OAEP_PARAMS_PTR;
 
 typedef struct CK_SSL3_RANDOM_DATA {
   CK_BYTE_PTR  pClientRandom;
@@ -1569,7 +1591,6 @@ typedef struct CK_SSL3_MASTER_KEY_DERIVE_PARAMS {
 
 typedef struct CK_SSL3_MASTER_KEY_DERIVE_PARAMS CK_PTR \
   CK_SSL3_MASTER_KEY_DERIVE_PARAMS_PTR;
-
 
 typedef struct CK_SSL3_KEY_MAT_OUT {
   CK_OBJECT_HANDLE hClientMacSecret;
@@ -1593,6 +1614,17 @@ typedef struct CK_SSL3_KEY_MAT_PARAMS {
 } CK_SSL3_KEY_MAT_PARAMS;
 
 typedef CK_SSL3_KEY_MAT_PARAMS CK_PTR CK_SSL3_KEY_MAT_PARAMS_PTR;
+
+typedef struct CK_TLS_PRF_PARAMS {
+  CK_BYTE_PTR  pSeed;
+  CK_ULONG     ulSeedLen;
+  CK_BYTE_PTR  pLabel;
+  CK_ULONG     ulLabelLen;
+  CK_BYTE_PTR  pOutput;
+  CK_ULONG_PTR pulOutputLen;
+} CK_TLS_PRF_PARAMS;
+
+typedef CK_TLS_PRF_PARAMS CK_PTR CK_TLS_PRF_PARAMS_PTR;
 
 typedef struct CK_WTLS_RANDOM_DATA {
   CK_BYTE_PTR pClientRandom;
@@ -1670,21 +1702,22 @@ typedef CK_KEY_DERIVATION_STRING_DATA CK_PTR \
 /* The CK_EXTRACT_PARAMS is used for the
  * CKM_EXTRACT_KEY_FROM_KEY mechanism.  It specifies which bit
  * of the base key should be used as the first bit of the
- * derived key */
+ * derived key
+ */
 typedef CK_ULONG CK_EXTRACT_PARAMS;
 
 typedef CK_EXTRACT_PARAMS CK_PTR CK_EXTRACT_PARAMS_PTR;
 
-/*
- * CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE is used to
+/* CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE is used to
  * indicate the Pseudo-Random Function (PRF) used to generate
- * key bits using PKCS #5 PBKDF2. */
+ * key bits using PKCS #5 PBKDF2.
+ */
 typedef CK_ULONG CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE;
 
-typedef CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE CK_PTR CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE_PTR;
+typedef CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE CK_PTR \
+                        CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE_PTR;
 
 #define CKP_PKCS5_PBKD2_HMAC_SHA1          0x00000001UL
-/* new for v2.40 */
 #define CKP_PKCS5_PBKD2_HMAC_GOSTR3411     0x00000002UL
 #define CKP_PKCS5_PBKD2_HMAC_SHA224        0x00000003UL
 #define CKP_PKCS5_PBKD2_HMAC_SHA256        0x00000004UL
@@ -1693,19 +1726,19 @@ typedef CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE CK_PTR CK_PKCS5_PBKD2_PSEUDO_
 #define CKP_PKCS5_PBKD2_HMAC_SHA512_224    0x00000007UL
 #define CKP_PKCS5_PBKD2_HMAC_SHA512_256    0x00000008UL
 
-/*
- * CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE is used to indicate the
+/* CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE is used to indicate the
  * source of the salt value when deriving a key using PKCS #5
- * PBKDF2. */
+ * PBKDF2.
+ */
 typedef CK_ULONG CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE;
 
-typedef CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE CK_PTR CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE_PTR;
+typedef CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE CK_PTR \
+                        CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE_PTR;
 
 /* The following salt value sources are defined in PKCS #5 v2.0. */
 #define CKZ_SALT_SPECIFIED        0x00000001UL
 
-/*
- * CK_PKCS5_PBKD2_PARAMS is a structure that provides the
+/* CK_PKCS5_PBKD2_PARAMS is a structure that provides the
  * parameters to the CKM_PKCS5_PBKD2 mechanism.
  */
 typedef struct CK_PKCS5_PBKD2_PARAMS {
@@ -1722,8 +1755,26 @@ typedef struct CK_PKCS5_PBKD2_PARAMS {
 
 typedef CK_PKCS5_PBKD2_PARAMS CK_PTR CK_PKCS5_PBKD2_PARAMS_PTR;
 
+/* CK_PKCS5_PBKD2_PARAMS2 is a corrected version of the CK_PKCS5_PBKD2_PARAMS
+ * structure that provides the parameters to the CKM_PKCS5_PBKD2 mechanism
+ * noting that the ulPasswordLen field is a CK_ULONG and not a CK_ULONG_PTR.
+ */
+typedef struct CK_PKCS5_PBKD2_PARAMS2 {
+        CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE saltSource;
+        CK_VOID_PTR pSaltSourceData;
+        CK_ULONG ulSaltSourceDataLen;
+        CK_ULONG iterations;
+        CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE prf;
+        CK_VOID_PTR pPrfData;
+        CK_ULONG ulPrfDataLen;
+        CK_UTF8CHAR_PTR pPassword;
+        CK_ULONG ulPasswordLen;
+} CK_PKCS5_PBKD2_PARAMS2;
+
+typedef CK_PKCS5_PBKD2_PARAMS2 CK_PTR CK_PKCS5_PBKD2_PARAMS2_PTR;
+
 typedef CK_ULONG CK_OTP_PARAM_TYPE;
-typedef CK_OTP_PARAM_TYPE CK_PARAM_TYPE; /* B/w compatibility */
+typedef CK_OTP_PARAM_TYPE CK_PARAM_TYPE; /* backward compatibility */
 
 typedef struct CK_OTP_PARAM {
     CK_OTP_PARAM_TYPE type;
@@ -1780,70 +1831,98 @@ typedef struct CK_AES_CTR_PARAMS {
 typedef CK_AES_CTR_PARAMS CK_PTR CK_AES_CTR_PARAMS_PTR;
 
 typedef struct CK_GCM_PARAMS {
+    CK_BYTE_PTR       pIv;
+    CK_ULONG          ulIvLen;
+    CK_ULONG          ulIvBits;
+    CK_BYTE_PTR       pAAD;
+    CK_ULONG          ulAADLen;
+    CK_ULONG          ulTagBits;
+} CK_GCM_PARAMS;
+
+typedef CK_GCM_PARAMS CK_PTR CK_GCM_PARAMS_PTR;
+
+typedef struct CK_CCM_PARAMS {
+    CK_ULONG          ulDataLen;
+    CK_BYTE_PTR       pNonce;
+    CK_ULONG          ulNonceLen;
+    CK_BYTE_PTR       pAAD;
+    CK_ULONG          ulAADLen;
+    CK_ULONG          ulMACLen;
+} CK_CCM_PARAMS;
+
+typedef CK_CCM_PARAMS CK_PTR CK_CCM_PARAMS_PTR;
+
+/* Deprecated. Use CK_GCM_PARAMS */
+typedef struct CK_AES_GCM_PARAMS {
   CK_BYTE_PTR pIv;
   CK_ULONG ulIvLen;
   CK_ULONG ulIvBits;
   CK_BYTE_PTR pAAD;
   CK_ULONG ulAADLen;
   CK_ULONG ulTagBits;
-} CK_GCM_PARAMS;
+} CK_AES_GCM_PARAMS;
 
-typedef CK_GCM_PARAMS CK_PTR CK_GCM_PARAMS_PTR;
+typedef CK_AES_GCM_PARAMS CK_PTR CK_AES_GCM_PARAMS_PTR;
 
-typedef struct CK_CCM_PARAMS {
-	CK_ULONG ulDataLen; /*plaintext or ciphertext*/
-	CK_BYTE_PTR pNonce;
-	CK_ULONG ulNonceLen;
-	CK_BYTE_PTR pAAD;
-	CK_ULONG ulAADLen;
-	CK_ULONG ulMACLen;
-} CK_CCM_PARAMS;
+/* Deprecated. Use CK_CCM_PARAMS */
+typedef struct CK_AES_CCM_PARAMS {
+    CK_ULONG          ulDataLen;
+    CK_BYTE_PTR       pNonce;
+    CK_ULONG          ulNonceLen;
+    CK_BYTE_PTR       pAAD;
+    CK_ULONG          ulAADLen;
+    CK_ULONG          ulMACLen;
+} CK_AES_CCM_PARAMS;
 
-typedef CK_CCM_PARAMS CK_PTR CK_CCM_PARAMS_PTR;
+typedef CK_AES_CCM_PARAMS CK_PTR CK_AES_CCM_PARAMS_PTR;
+
+typedef struct CK_CAMELLIA_CTR_PARAMS {
+    CK_ULONG          ulCounterBits;
+    CK_BYTE           cb[16];
+} CK_CAMELLIA_CTR_PARAMS;
+
+typedef CK_CAMELLIA_CTR_PARAMS CK_PTR CK_CAMELLIA_CTR_PARAMS_PTR;
 
 typedef struct CK_CAMELLIA_CBC_ENCRYPT_DATA_PARAMS {
-    CK_BYTE      iv[16];
-    CK_BYTE_PTR  pData;
-    CK_ULONG     length;
+    CK_BYTE           iv[16];
+    CK_BYTE_PTR       pData;
+    CK_ULONG          length;
 } CK_CAMELLIA_CBC_ENCRYPT_DATA_PARAMS;
 
-typedef CK_CAMELLIA_CBC_ENCRYPT_DATA_PARAMS CK_PTR CK_CAMELLIA_CBC_ENCRYPT_DATA_PARAMS_PTR;
+typedef CK_CAMELLIA_CBC_ENCRYPT_DATA_PARAMS CK_PTR \
+                                CK_CAMELLIA_CBC_ENCRYPT_DATA_PARAMS_PTR;
 
 typedef struct CK_ARIA_CBC_ENCRYPT_DATA_PARAMS {
-    CK_BYTE      iv[16];
-    CK_BYTE_PTR  pData;
-    CK_ULONG     length;
+    CK_BYTE           iv[16];
+    CK_BYTE_PTR       pData;
+    CK_ULONG          length;
 } CK_ARIA_CBC_ENCRYPT_DATA_PARAMS;
 
-typedef CK_ARIA_CBC_ENCRYPT_DATA_PARAMS CK_PTR CK_ARIA_CBC_ENCRYPT_DATA_PARAMS_PTR;
+typedef CK_ARIA_CBC_ENCRYPT_DATA_PARAMS CK_PTR \
+                                CK_ARIA_CBC_ENCRYPT_DATA_PARAMS_PTR;
 
-/* new for v2.40 */
 typedef struct CK_DSA_PARAMETER_GEN_PARAM {
-    CK_MECHANISM_TYPE   hash;
-    CK_BYTE_PTR         pSeed;
-    CK_ULONG            ulSeedLen;
-    CK_ULONG            ulIndex;
+    CK_MECHANISM_TYPE  hash;
+    CK_BYTE_PTR        pSeed;
+    CK_ULONG           ulSeedLen;
+    CK_ULONG           ulIndex;
 } CK_DSA_PARAMETER_GEN_PARAM;
 
 typedef CK_DSA_PARAMETER_GEN_PARAM CK_PTR CK_DSA_PARAMETER_GEN_PARAM_PTR;
 
-/* new for v2.40 */
 typedef struct CK_ECDH_AES_KEY_WRAP_PARAMS {
-    CK_ULONG                ulAESKeyBits;
-    CK_EC_KDF_TYPE          kdf;
-    CK_ULONG                ulSharedDataLen;
-    CK_BYTE_PTR             pSharedData;
+    CK_ULONG           ulAESKeyBits;
+    CK_EC_KDF_TYPE     kdf;
+    CK_ULONG           ulSharedDataLen;
+    CK_BYTE_PTR        pSharedData;
 } CK_ECDH_AES_KEY_WRAP_PARAMS;
 
 typedef CK_ECDH_AES_KEY_WRAP_PARAMS CK_PTR CK_ECDH_AES_KEY_WRAP_PARAMS_PTR;
 
-/* new for v2.40 */
 typedef CK_ULONG CK_JAVA_MIDP_SECURITY_DOMAIN;
 
-/* new for v2.40 */
 typedef CK_ULONG CK_CERTIFICATE_CATEGORY;
 
-/* new for v2.40 */
 typedef struct CK_RSA_AES_KEY_WRAP_PARAMS {
     CK_ULONG                      ulAESKeyBits;
     CK_RSA_PKCS_OAEP_PARAMS_PTR   pOAEPParams;
@@ -1851,16 +1930,15 @@ typedef struct CK_RSA_AES_KEY_WRAP_PARAMS {
 
 typedef CK_RSA_AES_KEY_WRAP_PARAMS CK_PTR CK_RSA_AES_KEY_WRAP_PARAMS_PTR;
 
-/* new for v2.40 */
 typedef struct CK_TLS12_MASTER_KEY_DERIVE_PARAMS {
     CK_SSL3_RANDOM_DATA       RandomInfo;
     CK_VERSION_PTR            pVersion;
     CK_MECHANISM_TYPE         prfHashMechanism;
 } CK_TLS12_MASTER_KEY_DERIVE_PARAMS;
 
-typedef CK_TLS12_MASTER_KEY_DERIVE_PARAMS CK_PTR CK_TLS12_MASTER_KEY_DERIVE_PARAMS_PTR;
+typedef CK_TLS12_MASTER_KEY_DERIVE_PARAMS CK_PTR \
+                                CK_TLS12_MASTER_KEY_DERIVE_PARAMS_PTR;
 
-/* new for v2.40 */
 typedef struct CK_TLS12_KEY_MAT_PARAMS {
     CK_ULONG                  ulMacSizeInBits;
     CK_ULONG                  ulKeySizeInBits;
@@ -1873,7 +1951,6 @@ typedef struct CK_TLS12_KEY_MAT_PARAMS {
 
 typedef CK_TLS12_KEY_MAT_PARAMS CK_PTR CK_TLS12_KEY_MAT_PARAMS_PTR;
 
-/* new for v2.40 */
 typedef struct CK_TLS_KDF_PARAMS {
     CK_MECHANISM_TYPE         prfMechanism;
     CK_BYTE_PTR               pLabel;
@@ -1885,7 +1962,6 @@ typedef struct CK_TLS_KDF_PARAMS {
 
 typedef CK_TLS_KDF_PARAMS CK_PTR CK_TLS_KDF_PARAMS_PTR;
 
-/* new for v2.40 */
 typedef struct CK_TLS_MAC_PARAMS {
     CK_MECHANISM_TYPE         prfHashMechanism;
     CK_ULONG                  ulMacLength;
@@ -1914,4 +1990,14 @@ typedef struct CK_GOSTR3410_KEY_WRAP_PARAMS {
 
 typedef CK_GOSTR3410_KEY_WRAP_PARAMS CK_PTR CK_GOSTR3410_KEY_WRAP_PARAMS_PTR;
 
-#endif
+typedef struct CK_SEED_CBC_ENCRYPT_DATA_PARAMS {
+    CK_BYTE                   iv[16];
+    CK_BYTE_PTR               pData;
+    CK_ULONG                  length;
+} CK_SEED_CBC_ENCRYPT_DATA_PARAMS;
+
+typedef CK_SEED_CBC_ENCRYPT_DATA_PARAMS CK_PTR \
+                                        CK_SEED_CBC_ENCRYPT_DATA_PARAMS_PTR;
+
+#endif /* _PKCS11T_H_ */
+

--- a/vendor/github.com/miekg/pkcs11/types.go
+++ b/vendor/github.com/miekg/pkcs11/types.go
@@ -5,18 +5,9 @@
 package pkcs11
 
 /*
-#define CK_PTR *
-#ifndef NULL_PTR
-#define NULL_PTR 0
-#endif
-#define CK_DEFINE_FUNCTION(returnType, name) returnType name
-#define CK_DECLARE_FUNCTION(returnType, name) returnType name
-#define CK_DECLARE_FUNCTION_POINTER(returnType, name) returnType (* name)
-#define CK_CALLBACK_FUNCTION(returnType, name) returnType (* name)
-
 #include <stdlib.h>
 #include <string.h>
-#include "pkcs11.h"
+#include "pkcs11go.h"
 
 CK_ULONG Index(CK_ULONG_PTR array, CK_ULONG i)
 {
@@ -196,20 +187,22 @@ func NewAttribute(typ uint, x interface{}) *Attribute {
 }
 
 // cAttribute returns the start address and the length of an attribute list.
-func cAttributeList(a []*Attribute) (arena, C.CK_ATTRIBUTE_PTR, C.CK_ULONG) {
+func cAttributeList(a []*Attribute) (arena, C.ckAttrPtr, C.CK_ULONG) {
 	var arena arena
 	if len(a) == 0 {
 		return nil, nil, 0
 	}
-	pa := make([]C.CK_ATTRIBUTE, len(a))
+	pa := make([]C.ckAttr, len(a))
 	for i := 0; i < len(a); i++ {
 		pa[i]._type = C.CK_ATTRIBUTE_TYPE(a[i].Type)
-		if a[i].Value == nil {
+		//skip attribute if length is 0 to prevent panic in arena.Allocate
+		if a[i].Value == nil || len(a[i].Value) == 0 {
 			continue
 		}
+
 		pa[i].pValue, pa[i].ulValueLen = arena.Allocate(a[i].Value)
 	}
-	return arena, C.CK_ATTRIBUTE_PTR(&pa[0]), C.CK_ULONG(len(a))
+	return arena, C.ckAttrPtr(&pa[0]), C.CK_ULONG(len(a))
 }
 
 func cDate(t time.Time) []byte {
@@ -243,20 +236,22 @@ func NewMechanism(mech uint, x interface{}) *Mechanism {
 	return m
 }
 
-func cMechanismList(m []*Mechanism) (arena, C.CK_MECHANISM_PTR, C.CK_ULONG) {
+func cMechanismList(m []*Mechanism) (arena, C.ckMechPtr, C.CK_ULONG) {
 	var arena arena
 	if len(m) == 0 {
 		return nil, nil, 0
 	}
-	pm := make([]C.CK_MECHANISM, len(m))
+	pm := make([]C.ckMech, len(m))
 	for i := 0; i < len(m); i++ {
 		pm[i].mechanism = C.CK_MECHANISM_TYPE(m[i].Mechanism)
-		if m[i].Parameter == nil {
+		//skip parameter if length is 0 to prevent panic in arena.Allocate
+		if m[i].Parameter == nil || len(m[i].Parameter) == 0 {
 			continue
 		}
+
 		pm[i].pParameter, pm[i].ulParameterLen = arena.Allocate(m[i].Parameter)
 	}
-	return arena, C.CK_MECHANISM_PTR(&pm[0]), C.CK_ULONG(len(m))
+	return arena, C.ckMechPtr(&pm[0]), C.CK_ULONG(len(m))
 }
 
 // MechanismInfo provides information about a particular mechanism.


### PR DESCRIPTION
This is a security fix release of Go, see https://go-review.googlesource.com/c/go/+/73392

Some of the fixes may be relevant for Notary.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>