### PR TITLE
Add some filepaths on Fedora where libykcs11 may be found

### DIFF
--- a/trustmanager/yubikey/pkcs11_linux.go
+++ b/trustmanager/yubikey/pkcs11_linux.go
@@ -4,7 +4,9 @@ package yubikey
 
 var possiblePkcs11Libs = []string{
 	"/usr/lib/libykcs11.so",
+	"/usr/lib/libykcs11.so.1",    // yubico-piv-tool on Fedora installs here
 	"/usr/lib64/libykcs11.so",
+	"/usr/lib64/libykcs11.so.1",  // yubico-piv-tool on Fedora installs here
 	"/usr/lib/x86_64-linux-gnu/libykcs11.so",
 	"/usr/local/lib/libykcs11.so",
 }

--- a/trustmanager/yubikey/pkcs11_linux.go
+++ b/trustmanager/yubikey/pkcs11_linux.go
@@ -4,9 +4,9 @@ package yubikey
 
 var possiblePkcs11Libs = []string{
 	"/usr/lib/libykcs11.so",
-	"/usr/lib/libykcs11.so.1",    // yubico-piv-tool on Fedora installs here
+	"/usr/lib/libykcs11.so.1", // yubico-piv-tool on Fedora installs here
 	"/usr/lib64/libykcs11.so",
-	"/usr/lib64/libykcs11.so.1",  // yubico-piv-tool on Fedora installs here
+	"/usr/lib64/libykcs11.so.1", // yubico-piv-tool on Fedora installs here
 	"/usr/lib/x86_64-linux-gnu/libykcs11.so",
 	"/usr/local/lib/libykcs11.so",
 }


### PR DESCRIPTION
I added some filepaths to the shared `libykcs11` library may be found on Fedora after installing `yubico-piv-tool`.

Signed-off-by: Trishank K Kuppusamy <trishank.kuppusamy@datadoghq.com>