### PR TITLE
Fix usage example for client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -30,7 +30,7 @@ Use this package by creating a new repository object and calling methods on it.
 
 		server := "https://notary.docker.io"
 		image := "docker.io/library/alpine"
-		repo, err := notary.NewFileCachedNotaryRepository(
+		repo, err := notary.NewFileCachedRepository(
 			rootDir,
 			data.GUN(image),
 			server,
@@ -38,6 +38,9 @@ Use this package by creating a new repository object and calling methods on it.
 			nil,
 			trustpinning.TrustPinConfig{},
 		)
+		if err != nil {
+			panic(err)
+		}
 
 		targets, err := repo.ListTargets()
 		if err != nil {


### PR DESCRIPTION
This fixes the example so it works again, and adds a missing error handler.

This really should be converted to a Go test example so it gets compile tested, but it is a bit long, ie two functions for good reason. Will think about how best to do this, but lets fix the error first.