### PR TITLE
Add python setuptools to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
 	xz-utils \
 	python \
 	python-pip \
+	python-setuptools \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
On s390x these are needed, not sure why there is a difference but
it is a harmless addition.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>