### PR TITLE
Bump the go-connections vendor so that we disable insecure RSA key exchange ciphers and require TLS >= 1.2

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -6,7 +6,7 @@ github.com/bugsnag/panicwrap	    e2c28503fcd0675329da73bf48b33404db873782
 github.com/bugsnag/osext	    0dd3f918b21bec95ace9dc86c7e70266cfc5c702
 github.com/docker/distribution      edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c
 github.com/opencontainers/go-digest a6d0ee40d4207ea02364bd3b9e8e77b9159ba1eb
-github.com/docker/go-connections    3ede32e2033de7505e6500d6c868c2b9ed9f169d
+github.com/docker/go-connections    7395e3f8aa162843a74ed6d48e79627d9792ac55
 github.com/docker/go                d30aec9fd63c35133f8f79c3412ad91a3b08be06
 github.com/dvsekhvalnov/jose2go     6387d3c1f5abd8443b223577d5a7e0f4e0e5731f   # v1.2
 github.com/go-sql-driver/mysql      a0583e0143b1624142adab07e0e97fe106d99561   # v1.3

--- a/vendor/github.com/docker/go-connections/tlsconfig/certpool_other.go
+++ b/vendor/github.com/docker/go-connections/tlsconfig/certpool_other.go
@@ -4,7 +4,6 @@ package tlsconfig
 
 import (
 	"crypto/x509"
-
 )
 
 // SystemCertPool returns an new empty cert pool,

--- a/vendor/github.com/docker/go-connections/tlsconfig/config.go
+++ b/vendor/github.com/docker/go-connections/tlsconfig/config.go
@@ -46,8 +46,6 @@ var acceptedCBCCiphers = []uint16{
 	tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
 	tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
 	tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-	tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-	tls.TLS_RSA_WITH_AES_128_CBC_SHA,
 }
 
 // DefaultServerAcceptedCiphers should be uses by code which already has a crypto/tls
@@ -65,22 +63,34 @@ var allTLSVersions = map[uint16]struct{}{
 }
 
 // ServerDefault returns a secure-enough TLS configuration for the server TLS configuration.
-func ServerDefault() *tls.Config {
-	return &tls.Config{
-		// Avoid fallback to SSL protocols < TLS1.0
-		MinVersion:               tls.VersionTLS10,
+func ServerDefault(ops ...func(*tls.Config)) *tls.Config {
+	tlsconfig := &tls.Config{
+		// Avoid fallback by default to SSL protocols < TLS1.2
+		MinVersion:               tls.VersionTLS12,
 		PreferServerCipherSuites: true,
 		CipherSuites:             DefaultServerAcceptedCiphers,
 	}
+
+	for _, op := range ops {
+		op(tlsconfig)
+	}
+
+	return tlsconfig
 }
 
 // ClientDefault returns a secure-enough TLS configuration for the client TLS configuration.
-func ClientDefault() *tls.Config {
-	return &tls.Config{
+func ClientDefault(ops ...func(*tls.Config)) *tls.Config {
+	tlsconfig := &tls.Config{
 		// Prefer TLS1.2 as the client minimum
 		MinVersion:   tls.VersionTLS12,
 		CipherSuites: clientCipherSuites,
 	}
+
+	for _, op := range ops {
+		op(tlsconfig)
+	}
+
+	return tlsconfig
 }
 
 // certPool returns an X.509 certificate pool from `caFile`, the certificate file.


### PR DESCRIPTION
If this is approved before https://github.com/theupdateframework/notary/pull/1306, ideally it would be included in the 0.6.0 release as well and I'll update the changelog and relevant branches.