### PR TITLE
Don't error out in case home cannot be found

### DIFF
--- a/cmd/notary/main.go
+++ b/cmd/notary/main.go
@@ -77,10 +77,9 @@ func (n *notaryCommander) parseConfig() (*viper.Viper, error) {
 	// Get home directory for current user
 	homeDir, err := homedir.Dir()
 	if err != nil {
-		return nil, fmt.Errorf("cannot get current user home directory: %v", err)
-	}
-	if homeDir == "" {
-		return nil, fmt.Errorf("cannot get current user home directory")
+		logrus.Warnf("cannot get current user home directory: %v", err)
+		pwd, _ := os.Getwd()
+		logrus.Warnf("notary will use %s to store configuration and keys", filepath.Join(pwd, configDir))
 	}
 
 	config := viper.New()


### PR DESCRIPTION
There is a few case where home could not be found (and would not be
needed). Especially as this piece of code is only there to set a
default value for a flag.

cc @cyli @n4ss @endophage 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>