### PR TITLE
Set the Notary Signer to be non dumpable in Linux

### DIFF
--- a/cmd/notary-signer/dump_linux.go
+++ b/cmd/notary-signer/dump_linux.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func protect() error {
+	// Make sure process is not dumpable, so will not core dump, which would
+	// write keys to disk, and cannot be ptraced to read keys.
+	return unix.Prctl(unix.PR_SET_DUMPABLE, 0, 0, 0, 0)
+}

--- a/cmd/notary-signer/dump_unsupported.go
+++ b/cmd/notary-signer/dump_unsupported.go
@@ -1,0 +1,7 @@
+// +build !linux
+
+package main
+
+func protect() error {
+	return nil
+}

--- a/cmd/notary-signer/main.go
+++ b/cmd/notary-signer/main.go
@@ -50,6 +50,11 @@ func main() {
 
 	if flagStorage.debug {
 		go debugServer(debugAddr)
+	} else {
+		// If not in debug mode, stop tracing, core dumps if supported to help protect keys.
+		if err := protect(); err != nil {
+			logrus.Fatal(err.Error())
+		}
 	}
 
 	// when the signer starts print the version for debugging and issue logs later


### PR DESCRIPTION
This disables
 - core dumps, which might contain keys
 - ability to ptrace the process which may allow keys to be read

This is not enabled in the debug mode.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>