### PR TITLE
Remove MAINTAINERS from Dockerfiles

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,5 +1,4 @@
 FROM docs/base:oss
-MAINTAINER Mary Anthony <mary@docker.com> (@moxiegirl)
 
 ENV PROJECT=notary
 

--- a/escrow.Dockerfile
+++ b/escrow.Dockerfile
@@ -1,5 +1,4 @@
 FROM golang:1.9.4-alpine
-MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 ENV NOTARYPKG github.com/theupdateframework/notary
 

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,5 +1,4 @@
 FROM golang:1.9.4-alpine
-MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 RUN apk add --update git gcc libc-dev && rm -rf /var/cache/apk/*
 

--- a/server.minimal.Dockerfile
+++ b/server.minimal.Dockerfile
@@ -17,7 +17,6 @@ RUN go install \
 
 
 FROM busybox:latest
-MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 # the ln is for compatibility with the docker-compose.yml, making these
 # images a straight swap for the those built in the compose file.

--- a/signer.Dockerfile
+++ b/signer.Dockerfile
@@ -1,5 +1,4 @@
 FROM golang:1.9.4-alpine
-MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 RUN apk add --update git gcc libc-dev && rm -rf /var/cache/apk/*
 

--- a/signer.minimal.Dockerfile
+++ b/signer.minimal.Dockerfile
@@ -17,7 +17,6 @@ RUN go install \
 
 
 FROM busybox:latest
-MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 # the ln is for compatibility with the docker-compose.yml, making these
 # images a straight swap for the those built in the compose file.


### PR DESCRIPTION
This field is deprecated, and maintaining Dockerfiles is the
responsibility of all the Notary maintainers.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>