### PR TITLE
Remove apk warnings

### DIFF
--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.9.4-alpine
 MAINTAINER David Lawrence "david.lawrence@docker.com"
 
-RUN apk add --update git gcc libc-dev && rm -rf /var/cache/apk/*
+RUN apk add --update git gcc libc-dev
 
 # Pin to the specific v3.0.0 version
 RUN go get -tags 'mysql postgres file' github.com/mattes/migrate/cli && mv /go/bin/cli /go/bin/migrate
@@ -22,7 +22,7 @@ EXPOSE 4443
 RUN go install \
     -tags pkcs11 \
     -ldflags "-w -X ${NOTARYPKG}/version.GitCommit=`git rev-parse --short HEAD` -X ${NOTARYPKG}/version.NotaryVersion=`cat NOTARY_VERSION`" \
-    ${NOTARYPKG}/cmd/notary-server && apk del git gcc libc-dev
+    ${NOTARYPKG}/cmd/notary-server && apk del git gcc libc-dev && rm -rf /var/cache/apk/*
 
 ENTRYPOINT [ "notary-server" ]
 CMD [ "-config=fixtures/server-config-local.json" ]

--- a/signer.Dockerfile
+++ b/signer.Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.9.4-alpine
 MAINTAINER David Lawrence "david.lawrence@docker.com"
 
-RUN apk add --update git gcc libc-dev && rm -rf /var/cache/apk/*
+RUN apk add --update git gcc libc-dev
 
 # Pin to the specific v3.0.0 version
 RUN go get -tags 'mysql postgres file' github.com/mattes/migrate/cli && mv /go/bin/cli /go/bin/migrate
@@ -23,7 +23,7 @@ ENV NOTARY_SIGNER_TIMESTAMP_1="testpassword"
 RUN go install \
     -tags pkcs11 \
     -ldflags "-w -X ${NOTARYPKG}/version.GitCommit=`git rev-parse --short HEAD` -X ${NOTARYPKG}/version.NotaryVersion=`cat NOTARY_VERSION`" \
-    ${NOTARYPKG}/cmd/notary-signer && apk del git gcc libc-dev
+    ${NOTARYPKG}/cmd/notary-signer && apk del git gcc libc-dev && rm -rf /var/cache/apk/*
 
 ENTRYPOINT [ "notary-signer" ]
 CMD [ "-config=fixtures/signer-config-local.json" ]


### PR DESCRIPTION
Because we deleted the apk cache and then did apk operations, a large
warning was appearing. Reorder the operations so the build logs are cleaner.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>