### PR TITLE
Add another note about serialization of ed25519 keys

### DIFF
--- a/tuf/data/keys.go
+++ b/tuf/data/keys.go
@@ -485,6 +485,7 @@ func (k RSAPrivateKey) Sign(rand io.Reader, msg []byte, opts crypto.SignerOpts) 
 // Sign creates an ed25519 signature
 func (k ED25519PrivateKey) Sign(rand io.Reader, msg []byte, opts crypto.SignerOpts) (signature []byte, err error) {
 	priv := [ed25519.PrivateKeySize]byte{}
+	// The ed25519 key is serialized as public key then private key, so just use private key here.
 	copy(priv[:], k.private[ed25519.PublicKeySize:])
 	return ed25519.Sign(&priv, msg)[:], nil
 }


### PR DESCRIPTION
This really confused me today, as it only appears to copy part of
the private key. As stated in other files we are storing public key
concatenated with public key here.

We did not need to do this as the second half of an ed25519 private
key is the public key, so documenting it definitely reduces confusion.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>