### PR TITLE
Do not leak cancellations for contexts

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -38,7 +38,8 @@ func TestRunBadAddr(t *testing.T) {
 }
 
 func TestRunReservedPort(t *testing.T) {
-	ctx, _ := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	err := Run(
 		ctx,

--- a/signer/client/signer_trust.go
+++ b/signer/client/signer_trust.go
@@ -104,7 +104,8 @@ type NotarySigner struct {
 }
 
 func healthCheck(d time.Duration, hc healthpb.HealthClient, serviceName string) (*healthpb.HealthCheckResponse, error) {
-	ctx, _ := context.WithTimeout(context.Background(), d)
+	ctx, cancel := context.WithTimeout(context.Background(), d)
+	defer cancel()
 	req := &healthpb.HealthCheckRequest{
 		Service: serviceName,
 	}


### PR DESCRIPTION
You have to call the cancellation, or it will leak if it is not called,
in the common case when the timeout is not reached.

The docs say "Canceling this context releases resources associated with it,
so code should call cancel as soon as the operations running in this Context
complete".

Signed-off-by: Justin Cormack <justin.cormack@docker.com>