### PR TITLE
Add libpython-dev to CirclCI build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,8 @@ machine:
   # Upgrade docker
     - curl -sSL https://s3.amazonaws.com/circle-downloads/install-circleci-docker.sh | bash -s -- 1.10.0
   # upgrade compose
+    - sudo apt update
+    - sudo apt install libpython-dev
     - sudo pip install --upgrade docker-compose
 
   services:


### PR DESCRIPTION
Build is failing not being able to find python.h on CircleCI in #1361

Signed-off-by: Justin Cormack <justin.cormack@docker.com>