### PR TITLE
PKCS#11 support (targetting nShield HSMs and SoftHSM)

### DIFF
--- a/client/backwards_compatibility_test.go
+++ b/client/backwards_compatibility_test.go
@@ -216,7 +216,7 @@ func Test0Dot1RepoFormat(t *testing.T) {
 	require.NoError(t, repo.cache.Remove(data.CanonicalTimestampRole.String()))
 
 	// rotate the timestamp key, since the server doesn't have that one
-	err = repo.RotateKey(data.CanonicalTimestampRole, true, nil)
+	err = repo.RotateKey(data.CanonicalTimestampRole, true, "", "",nil)
 	require.NoError(t, err)
 
 	require.NoError(t, repo.Publish())
@@ -227,7 +227,7 @@ func Test0Dot1RepoFormat(t *testing.T) {
 
 	// Also check that we can add/remove keys by rotating keys
 	oldTargetsKeys := repo.GetCryptoService().ListKeys(data.CanonicalTargetsRole)
-	require.NoError(t, repo.RotateKey(data.CanonicalTargetsRole, false, nil))
+	require.NoError(t, repo.RotateKey(data.CanonicalTargetsRole, false, "", "", nil))
 	require.NoError(t, repo.Publish())
 	newTargetsKeys := repo.GetCryptoService().ListKeys(data.CanonicalTargetsRole)
 
@@ -237,7 +237,7 @@ func Test0Dot1RepoFormat(t *testing.T) {
 
 	// rotate the snapshot key to the server and ensure that the server can re-generate the snapshot
 	// and we can download the snapshot
-	require.NoError(t, repo.RotateKey(data.CanonicalSnapshotRole, true, nil))
+	require.NoError(t, repo.RotateKey(data.CanonicalSnapshotRole, true, "", "",nil))
 	require.NoError(t, repo.Publish())
 	err = repo.Update(false)
 	require.NoError(t, err)
@@ -279,7 +279,7 @@ func Test0Dot3RepoFormat(t *testing.T) {
 	require.NoError(t, repo.cache.Remove(data.CanonicalTimestampRole.String()))
 
 	// rotate the timestamp key, since the server doesn't have that one
-	err = repo.RotateKey(data.CanonicalTimestampRole, true, nil)
+	err = repo.RotateKey(data.CanonicalTimestampRole, true, "", "", nil)
 	require.NoError(t, err)
 
 	require.NoError(t, repo.Publish())
@@ -295,7 +295,7 @@ func Test0Dot3RepoFormat(t *testing.T) {
 
 	// Also check that we can add/remove keys by rotating keys
 	oldTargetsKeys := repo.GetCryptoService().ListKeys(data.CanonicalTargetsRole)
-	require.NoError(t, repo.RotateKey(data.CanonicalTargetsRole, false, nil))
+	require.NoError(t, repo.RotateKey(data.CanonicalTargetsRole, false, "", "",nil))
 	require.NoError(t, repo.Publish())
 	newTargetsKeys := repo.GetCryptoService().ListKeys(data.CanonicalTargetsRole)
 
@@ -305,7 +305,7 @@ func Test0Dot3RepoFormat(t *testing.T) {
 
 	// rotate the snapshot key to the server and ensure that the server can re-generate the snapshot
 	// and we can download the snapshot
-	require.NoError(t, repo.RotateKey(data.CanonicalSnapshotRole, true, nil))
+	require.NoError(t, repo.RotateKey(data.CanonicalSnapshotRole, true, "", "",nil))
 	require.NoError(t, repo.Publish())
 	err = repo.Update(false)
 	require.NoError(t, err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2681,31 +2681,31 @@ func TestRotateKeyInvalidRole(t *testing.T) {
 	require.NoError(t, repo.Update(false))
 
 	// rotating a root key to the server fails
-	require.Error(t, repo.RotateKey(data.CanonicalRootRole, true, nil),
+	require.Error(t, repo.RotateKey(data.CanonicalRootRole, true, "", "", nil),
 		"Rotating a root key with server-managing the key should fail")
 
 	// rotating a targets key to the server fails
-	require.Error(t, repo.RotateKey(data.CanonicalTargetsRole, true, nil),
+	require.Error(t, repo.RotateKey(data.CanonicalTargetsRole, true, "", "",nil),
 		"Rotating a targets key with server-managing the key should fail")
 
 	// rotating a timestamp key locally fails
-	require.Error(t, repo.RotateKey(data.CanonicalTimestampRole, false, nil),
+	require.Error(t, repo.RotateKey(data.CanonicalTimestampRole, false,"", "",nil),
 		"Rotating a timestamp key locally should fail")
 
 	// rotating a delegation key fails
-	require.Error(t, repo.RotateKey("targets/releases", false, nil),
+	require.Error(t, repo.RotateKey("targets/releases", false, "", "",nil),
 		"Rotating a delegation key should fail")
 
 	// rotating a delegation key to the server also fails
-	require.Error(t, repo.RotateKey("targets/releases", true, nil),
+	require.Error(t, repo.RotateKey("targets/releases", true, "", "",nil),
 		"Rotating a delegation key should fail")
 
 	// rotating a not a real role key fails
-	require.Error(t, repo.RotateKey("nope", false, nil),
+	require.Error(t, repo.RotateKey("nope", false, "", "",nil),
 		"Rotating a non-real role key should fail")
 
 	// rotating a not a real role key to the server also fails
-	require.Error(t, repo.RotateKey("nope", true, nil),
+	require.Error(t, repo.RotateKey("nope", true, "", "",nil),
 		"Rotating a non-real role key should fail")
 }
 
@@ -2720,7 +2720,7 @@ func TestRemoteRotationError(t *testing.T) {
 
 	// server has died, so this should fail
 	for _, role := range []data.RoleName{data.CanonicalSnapshotRole, data.CanonicalTimestampRole} {
-		err := repo.RotateKey(role, true, nil)
+		err := repo.RotateKey(role, true, "", "",nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unable to rotate remote key")
 	}
@@ -2735,7 +2735,7 @@ func TestRemoteRotationEndpointError(t *testing.T) {
 
 	// simpleTestServer has no rotate key endpoint, so this should fail
 	for _, role := range []data.RoleName{data.CanonicalSnapshotRole, data.CanonicalTimestampRole} {
-		err := repo.RotateKey(role, true, nil)
+		err := repo.RotateKey(role, true, "", "",nil)
 		require.Error(t, err)
 		require.IsType(t, store.ErrMetaNotFound{}, err)
 	}
@@ -2756,7 +2756,7 @@ func TestRemoteRotationNoRootKey(t *testing.T) {
 	_, err := newRepo.ListTargets()
 	require.NoError(t, err)
 
-	err = newRepo.RotateKey(data.CanonicalSnapshotRole, true, nil)
+	err = newRepo.RotateKey(data.CanonicalSnapshotRole, true, "", "",nil)
 	require.Error(t, err)
 	require.IsType(t, signed.ErrInsufficientSignatures{}, err)
 }
@@ -2770,7 +2770,7 @@ func TestRemoteRotationNoInit(t *testing.T) {
 	repo, baseDir := newBlankRepo(t, ts.URL)
 	defer os.RemoveAll(baseDir)
 
-	err := repo.RotateKey(data.CanonicalTimestampRole, true, nil)
+	err := repo.RotateKey(data.CanonicalTimestampRole, true, "", "",nil)
 	require.NoError(t, err)
 }
 
@@ -2797,7 +2797,7 @@ func requireRotationSuccessful(t *testing.T, repo1 *repository, keysToRotate map
 
 	// Do rotation
 	for role, serverManaged := range keysToRotate {
-		require.NoError(t, repo1.RotateKey(role, serverManaged, nil))
+		require.NoError(t, repo1.RotateKey(role, serverManaged, "", "",nil))
 	}
 
 	changesPost := getChanges(t, repo1)
@@ -2988,7 +2988,7 @@ func TestRotateRootKey(t *testing.T) {
 
 	// Rotate root certificate and key.
 	logRepoTrustRoot(t, "original", authorRepo)
-	err = authorRepo.RotateKey(data.CanonicalRootRole, false, nil)
+	err = authorRepo.RotateKey(data.CanonicalRootRole, false, "", "",nil)
 	require.NoError(t, err)
 	logRepoTrustRoot(t, "post-rotate", authorRepo)
 
@@ -3060,12 +3060,12 @@ func TestRotateRootMultiple(t *testing.T) {
 
 	// Rotate root certificate and key.
 	logRepoTrustRoot(t, "original", authorRepo)
-	err = authorRepo.RotateKey(data.CanonicalRootRole, false, nil)
+	err = authorRepo.RotateKey(data.CanonicalRootRole, false, "", "",nil)
 	require.NoError(t, err)
 	logRepoTrustRoot(t, "post-rotate", authorRepo)
 
 	// Rotate root certificate and key again.
-	err = authorRepo.RotateKey(data.CanonicalRootRole, false, nil)
+	err = authorRepo.RotateKey(data.CanonicalRootRole, false, "", "",nil)
 	require.NoError(t, err)
 	logRepoTrustRoot(t, "post-rotate-again", authorRepo)
 
@@ -3144,12 +3144,12 @@ func TestRotateRootKeyProvided(t *testing.T) {
 	require.NoError(t, err)
 
 	// Fail to rotate to bad key
-	err = authorRepo.RotateKey(data.CanonicalRootRole, false, []string{"notakey"})
+	err = authorRepo.RotateKey(data.CanonicalRootRole, false, "", "",[]string{"notakey"})
 	require.Error(t, err)
 
 	// Rotate root certificate and key.
 	logRepoTrustRoot(t, "original", authorRepo)
-	err = authorRepo.RotateKey(data.CanonicalRootRole, false, []string{rootPrivateKey.ID()})
+	err = authorRepo.RotateKey(data.CanonicalRootRole, false, "", "",[]string{rootPrivateKey.ID()})
 	require.NoError(t, err)
 	logRepoTrustRoot(t, "post-rotate", authorRepo)
 
@@ -3222,13 +3222,13 @@ func TestRotateRootKeyLegacySupport(t *testing.T) {
 
 	// Rotate root certificate and key.
 	logRepoTrustRoot(t, "original", authorRepo)
-	err = authorRepo.RotateKey(data.CanonicalRootRole, false, nil)
+	err = authorRepo.RotateKey(data.CanonicalRootRole, false, "", "",nil)
 	require.NoError(t, err)
 	logRepoTrustRoot(t, "post-rotate", authorRepo)
 
 	// Rotate root certificate and key again, this time with legacy support
 	authorRepo.LegacyVersions = SignWithAllOldVersions
-	err = authorRepo.RotateKey(data.CanonicalRootRole, false, nil)
+	err = authorRepo.RotateKey(data.CanonicalRootRole, false, "", "",nil)
 	require.NoError(t, err)
 	logRepoTrustRoot(t, "post-rotate-again", authorRepo)
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -385,7 +385,7 @@ func TestInitRepositoryWithCerts(t *testing.T) {
 				iDs = []string{}
 			}
 
-			err = repo.initialize(iDs, pubKeys, data.CanonicalTimestampRole)
+			err = repo.initialize(iDs, pubKeys, nil, data.CanonicalTimestampRole)
 			if len(iDs) == len(pubKeys) || // case: 2 keys 2 certs
 				(len(iDs) != 0 && len(pubKeys) == 0) || // case: 1 key and 0 cert
 				(len(iDs) == 0 && len(pubKeys) != 0) { // case: 0 keys and 1 cert
@@ -397,7 +397,7 @@ func TestInitRepositoryWithCerts(t *testing.T) {
 			}
 			// implicit else case: 2 keys 1 cert
 		} else { // unmatched key pairs case
-			err = repo.initialize(pubKeyIDs[1:], pubKeys[:1])
+			err = repo.initialize(pubKeyIDs[1:],  pubKeys[:1], nil)
 		}
 		require.Error(t, err, tc.expectedError, tc.name)
 		require.Nil(t, repo.tufRepo)

--- a/client/interface.go
+++ b/client/interface.go
@@ -10,7 +10,7 @@ import (
 type Repository interface {
 	// General management operations
 	Initialize(rootKeyIDs []string, serverManagedRoles ...data.RoleName) error
-	InitializeWithCertificate(rootKeyIDs []string, rootCerts []data.PublicKey, serverManagedRoles ...data.RoleName) error
+	InitializeWithCertificate(rootKeyIDs []string, rootCerts []data.PublicKey, roleKeys map[data.RoleName]data.PublicKey, serverManagedRoles ...data.RoleName) error
 	Publish() error
 
 	// Target Operations

--- a/client/interface.go
+++ b/client/interface.go
@@ -39,7 +39,7 @@ type Repository interface {
 	Witness(roles ...data.RoleName) ([]data.RoleName, error)
 
 	// Key Operations
-	RotateKey(role data.RoleName, serverManagesKey bool, keyList []string) error
+	RotateKey(role data.RoleName, serverManagesKey bool, keystoreName string, token string, keyList []string) error
 
 	GetCryptoService() signed.CryptoService
 	SetLegacyVersions(int)

--- a/client/repo.go
+++ b/client/repo.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/theupdateframework/notary"
 	"github.com/theupdateframework/notary/trustmanager"
+	"github.com/theupdateframework/notary/trustmanager/p11store"
 )
 
 func getKeyStores(baseDir string, retriever notary.PassRetriever) ([]trustmanager.KeyStore, error) {
@@ -14,5 +15,13 @@ func getKeyStores(baseDir string, retriever notary.PassRetriever) ([]trustmanage
 	if err != nil {
 		return nil, fmt.Errorf("failed to create private key store in directory: %s", baseDir)
 	}
-	return []trustmanager.KeyStore{fileKeyStore}, nil
+	keyStores := []trustmanager.KeyStore{fileKeyStore}
+	var pkcs11 *p11store.Pkcs11Store
+	if pkcs11, err = p11store.NewPkcs11Store("", retriever); err == nil {
+		keyStores = append(keyStores, pkcs11)
+	} else if err != p11store.ErrNoProvider {
+		// A PKCS#11 provider was configured but something went wrong setting it up
+		return nil, err
+	} // else nothing was configured
+	return keyStores, nil
 }

--- a/client/repo_pkcs11.go
+++ b/client/repo_pkcs11.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/theupdateframework/notary"
 	"github.com/theupdateframework/notary/trustmanager"
+	"github.com/theupdateframework/notary/trustmanager/p11store"
 	"github.com/theupdateframework/notary/trustmanager/yubikey"
 )
 
@@ -21,5 +22,12 @@ func getKeyStores(baseDir string, retriever notary.PassRetriever) ([]trustmanage
 	if yubiKeyStore != nil {
 		keyStores = []trustmanager.KeyStore{yubiKeyStore, fileKeyStore}
 	}
+	var pkcs11 *p11store.Pkcs11Store
+	if pkcs11, err = p11store.NewPkcs11Store("", retriever); err == nil {
+		keyStores = append(keyStores, pkcs11)
+	} else if err != p11store.ErrNoProvider {
+		// A PKCS#11 provider was configured but something went wrong setting it up
+		return nil, err
+	} // else nothing was configured
 	return keyStores, nil
 }

--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -94,6 +94,7 @@ type keyCommander struct {
 
 	importRole    string
 	generateRole  string
+	generateGun   string
 	keysImportGUN string
 	exportGUNs    []string
 	exportKeyIDs  []string
@@ -129,6 +130,9 @@ func (k *keyCommander) GetCommand() *cobra.Command {
 	)
 	cmdGenerate.Flags().StringVarP(
 		&k.generateRole, "role", "r", "root", "Role to generate key with, defaulting to \"root\".",
+	)
+	cmdGenerate.Flags().StringVarP(
+		&k.generateGun, "gun", "g", "", "GUN to generate key with.",
 	)
 	cmd.AddCommand(cmdGenerate)
 	cmd.AddCommand(cmdKeyRemoveTemplate.ToCommand(k.keyRemove))
@@ -251,7 +255,7 @@ func (k *keyCommander) keysGenerate(cmd *cobra.Command, args []string) error {
 		}
 		cs := cryptoservice.NewCryptoService(ks...)
 
-		pubKey, err := cs.Generate(data.RoleName(k.generateRole), "", k.keyStore, k.token, algorithm)
+		pubKey, err := cs.Generate(data.RoleName(k.generateRole), data.GUN(k.generateGun), k.keyStore, k.token, algorithm)
 		if err != nil {
 			return fmt.Errorf("Failed to create a new %s key: %v", k.generateRole, err)
 		}

--- a/const.go
+++ b/const.go
@@ -58,6 +58,7 @@ const (
 	SQLiteBackend    = "sqlite3"
 	RethinkDBBackend = "rethinkdb"
 	FileBackend      = "file"
+	Pkcs11Backend    = "pkcs11"
 
 	DefaultImportRole = "delegation"
 
@@ -92,4 +93,5 @@ var NotarySupportedBackends = []string{
 	SQLiteBackend,
 	RethinkDBBackend,
 	PostgresBackend,
+	Pkcs11Backend,
 }

--- a/docker-compose-pkcs11.yml
+++ b/docker-compose-pkcs11.yml
@@ -1,0 +1,60 @@
+version: "3.2"
+services:
+  server:
+    build:
+      context: .
+      dockerfile: server.Dockerfile
+    networks:
+      - mdb
+      - sig
+    ports:
+      - "8080"
+      - "4443:4443"
+    entrypoint: /usr/bin/env sh
+    command: -c "./migrations/migrate.sh && notary-server -config=fixtures/server-config.json"
+    depends_on:
+      - mysql
+      - signer
+  signer:
+    build:
+      context: .
+      dockerfile: signer.Dockerfile
+    networks:
+      sig:
+        aliases:
+          - notarysigner
+    volumes:
+      - type: bind
+        source: /opt/nfast/toolkits/pkcs11
+        target: /opt/nfast/toolkits/pkcs11
+        read_only: true
+      - type: bind
+        source: /opt/nfast/sockets/nserver
+        target: /opt/nfast/sockets/nserver
+        read_only: true
+      - type: bind
+        source: /opt/nfast/kmdata/local
+        target: /opt/nfast/kmdata/local
+    environment:
+      - NOTARY_HSM_PIN
+    entrypoint: /usr/bin/env sh
+    command: -c "CKNFAST_ASSUME_SINGLE_PROCESS=0 notary-signer -config=fixtures/signer-config-pkcs11.json"
+  mysql:
+    networks:
+      - mdb
+    volumes:
+      - ./notarysql/mysql-initdb.d:/docker-entrypoint-initdb.d
+      - notary_data:/var/lib/mysql
+    image: mariadb:10.1.28
+    environment:
+      - TERM=dumb
+      - MYSQL_ALLOW_EMPTY_PASSWORD="true"
+    command: mysqld --innodb_file_per_table
+volumes:
+  notary_data:
+    external: false
+networks:
+  mdb:
+    external: false
+  sig:
+    external: false

--- a/fixtures/signer-config-pkcs11.json
+++ b/fixtures/signer-config-pkcs11.json
@@ -1,0 +1,16 @@
+{
+	"server": {
+		"grpc_addr": ":7899",
+		"tls_cert_file": "./notary-signer.crt",
+		"tls_key_file": "./notary-signer.key",
+		"client_ca_file": "./notary-server.crt"
+	},
+	"logging": {
+		"level": "debug"
+	},
+	"storage": {
+		"backend": "pkcs11",
+		"provider": "/opt/nfast/toolkits/pkcs11/libcknfast.so",
+		"token": "label:ocs2"
+	}
+}

--- a/passphrase/passphrase.go
+++ b/passphrase/passphrase.go
@@ -117,6 +117,8 @@ func (br *boundRetriever) requestPassphrase(keyName, alias string, createNew boo
 		fmt.Fprintf(br.out, "Enter passphrase for new %s key%s: ", displayAlias, withID)
 	case displayAlias == "yubikey":
 		fmt.Fprintf(br.out, "Enter the %s for the attached Yubikey: ", keyName)
+	case displayAlias == "pkcs11":
+		fmt.Fprintf(br.out, "Enter the passphrase for the PKCS#11 token '%s': ", keyName)
 	default:
 		fmt.Fprintf(br.out, "Enter passphrase for %s key%s: ", displayAlias, withID)
 	}

--- a/signer.Dockerfile
+++ b/signer.Dockerfile
@@ -1,6 +1,11 @@
-FROM golang:1.10.3-alpine
+FROM golang:1.10.3-stretch
 
-RUN apk add --update git gcc libc-dev
+# libltdl-dev needed for PKCS#11 support.
+RUN apt-get update
+RUN apt-get -y --no-install-recommends install git build-essential libltdl-dev libltdl7
+
+# Some scripts depend on sh=bash (which is a bug but who has the time...)
+RUN ln -sf /bin/bash /bin/sh
 
 # Pin to the specific v3.0.0 version
 RUN go get -tags 'mysql postgres file' github.com/mattes/migrate/cli && mv /go/bin/cli /go/bin/migrate
@@ -22,7 +27,12 @@ ENV NOTARY_SIGNER_TIMESTAMP_1="testpassword"
 RUN go install \
     -tags pkcs11 \
     -ldflags "-w -X ${NOTARYPKG}/version.GitCommit=`git rev-parse --short HEAD` -X ${NOTARYPKG}/version.NotaryVersion=`cat NOTARY_VERSION`" \
-    ${NOTARYPKG}/cmd/notary-signer && apk del git gcc libc-dev && rm -rf /var/cache/apk/*
+    ${NOTARYPKG}/cmd/notary-signer
+
+# Remove a stack of stuff we don't need
+RUN apt-get -y purge git build-essential libltdl-dev gcc g++ python perl subversion openssl openssh-client make
+RUN apt-get -y autoremove
+RUN rm -rf /var/cache/apt
 
 ENTRYPOINT [ "notary-signer" ]
 CMD [ "-config=fixtures/signer-config-local.json" ]

--- a/trustmanager/interfaces.go
+++ b/trustmanager/interfaces.go
@@ -51,4 +51,14 @@ type KeyStore interface {
 	ListKeys() map[string]KeyInfo
 	RemoveKey(keyID string) error
 	Name() string
+
+	// Generate generates a new key and adds it to the keystore.
+	//
+	// The meaning of token depends on the key store but is intended
+	// to control how/where the key is stored (for instance, selecting
+	// between different possible smartcards). It should be "" if
+	// the key store has no such concept.
+	//
+	// algorithm can be ECDSAKey, RSAKey, etc.
+	Generate(keyInfo KeyInfo, token, algorithm string) (keyID string, pubKey data.PublicKey, err error)
 }

--- a/trustmanager/keystore.go
+++ b/trustmanager/keystore.go
@@ -186,6 +186,28 @@ func (s *GenericKeyStore) Name() string {
 	return s.store.Location()
 }
 
+// Generate generates a key and adds it to the keystore.
+func (p *GenericKeyStore) Generate(keyInfo KeyInfo, token, algorithm string) (keyID string, pubKey data.PublicKey, err error) {
+	// Only specialized keystores support multiple tokens.
+	if token != "" {
+		err = fmt.Errorf("key store %s does not support multiple tokens", p.Name())
+		return
+	}
+	// Generate the key
+	var privKey data.PrivateKey
+	if privKey, err = utils.GenerateKey(algorithm); err != nil {
+		return
+	}
+	// Compute the public key
+	pubKey = data.PublicKeyFromPrivate(privKey)
+	// Add it to the key store
+	if err = p.AddKey(keyInfo, privKey); err == nil {
+		return
+	}
+	// Success
+	return
+}
+
 // copyKeyInfoMap returns a deep copy of the passed-in keyInfoMap
 func copyKeyInfoMap(keyInfoMap map[string]KeyInfo) map[string]KeyInfo {
 	copyMap := make(map[string]KeyInfo)

--- a/trustmanager/p11store/p11cryptoservice.go
+++ b/trustmanager/p11store/p11cryptoservice.go
@@ -1,0 +1,60 @@
+package p11store
+
+import (
+	"github.com/theupdateframework/notary/tuf/data"
+	"errors"
+	"github.com/theupdateframework/notary/trustmanager"
+)
+
+// Pkcs11CryptoService is a signed.CryptoService which uses a chosen
+// token for PKCS#11 operations.
+type Pkcs11CryptoService struct {
+	// Underyling key store to use.
+	Store *Pkcs11Store
+
+	// Token to use for key generation.
+	Token string
+}
+
+func (ps *Pkcs11CryptoService) Create(role data.RoleName, gun data.GUN, algorithm string) (pubKey data.PublicKey, err error) {
+	_, pubKey, err = ps.Store.Generate(trustmanager.KeyInfo{gun, role}, ps.Token, algorithm)
+	return
+}
+
+func (ps *Pkcs11CryptoService) AddKey(role data.RoleName, gun data.GUN, key data.PrivateKey) (err error) {
+	err = errors.New("Pkcs11CryptoService.AddKey not implemented")
+	return
+}
+
+func (ps *Pkcs11CryptoService) GetKey(keyID string) (pubKey data.PublicKey) {
+	privKey, _, err := ps.Store.GetKey(keyID)
+	if err != nil {
+		return
+	}
+	pubKey = privKey
+	return
+}
+
+func (ps *Pkcs11CryptoService) GetPrivateKey(keyID string) (privKey data.PrivateKey, role data.RoleName, err error) {
+	privKey, role, err = ps.Store.GetKey(keyID)
+	return
+}
+
+func (ps *Pkcs11CryptoService) RemoveKey(keyID string) error {
+	return ps.Store.RemoveKey(keyID)
+}
+
+func (ps *Pkcs11CryptoService) ListKeys(role data.RoleName) (keyIDs []string) {
+	for keyID, _ := range ps.Store.ListKeys() {
+		keyIDs = append(keyIDs, keyID)
+	}
+	return
+}
+
+func (ps *Pkcs11CryptoService) ListAllKeys() (keyRoles map[string]data.RoleName) {
+	keyRoles = map[string]data.RoleName{}
+	for keyID, keyInfo := range ps.Store.ListKeys() {
+		keyRoles[keyID] = keyInfo.Role
+	}
+	return
+}

--- a/trustmanager/p11store/p11key.go
+++ b/trustmanager/p11store/p11key.go
@@ -1,0 +1,61 @@
+package p11store
+
+import (
+	"crypto"
+	"crypto/sha256"
+	"github.com/miekg/pkcs11"
+	"github.com/theupdateframework/notary/tuf/data"
+	"io"
+)
+
+// Pkcs11PrivateKey represents a handle to a private key in a PKCS#11
+// token.
+type Pkcs11PrivateKey struct {
+	data.TUFKey
+
+	// The owning PKCS#11 key store
+	Store *Pkcs11Store
+
+	// An RW session onto the token containing this key
+	Session pkcs11.SessionHandle
+
+	// The PKCS#11 object handle for the private key object
+	Object pkcs11.ObjectHandle
+
+	// The public key.
+	PublicKey crypto.PublicKey
+}
+
+// data.PrivateKey methods
+
+func (k *Pkcs11PrivateKey) Sign(rand io.Reader, msg []byte, opts crypto.SignerOpts) (signature []byte, err error) {
+	k.Store.lock.Lock()
+	defer k.Store.lock.Unlock()
+	// Despite looking superficially similar to crypto.Signer.Sign,
+	// data.PrivateKey.Sign takes a whole message.
+	digest := sha256.Sum256(msg)
+	mechanism := []*pkcs11.Mechanism{
+		pkcs11.NewMechanism(pkcs11.CKM_ECDSA, nil),
+	}
+	if err = k.Store.ctx.SignInit(k.Session, mechanism, k.Object); err != nil {
+		return
+	}
+	if signature, err = k.Store.ctx.Sign(k.Session, digest[:]); err != nil {
+		return
+	}
+	// Despite looking superficially similar to crypto.Signer.Sign,
+	// data.PrivateKey.Sign returns r || s (with lengths of both normalized).
+	return
+}
+
+func (k *Pkcs11PrivateKey) Private() []byte {
+	panic("cannot get private half of PKCS#11 key") // No better way to return an error
+}
+
+func (k *Pkcs11PrivateKey) CryptoSigner() crypto.Signer {
+	return &Pkcs11Signer{k} // Shim to work around interface mismatch
+}
+
+func (k *Pkcs11PrivateKey) SignatureAlgorithm() data.SigAlgorithm {
+	return data.ECDSASignature
+}

--- a/trustmanager/p11store/p11signer.go
+++ b/trustmanager/p11store/p11signer.go
@@ -1,0 +1,51 @@
+package p11store
+
+import (
+	"crypto"
+	"encoding/asn1"
+	"github.com/miekg/pkcs11"
+	"io"
+	"math/big"
+)
+
+// crypto.Signer support
+
+// dsaSignature represents a DSA or ECDSA signature
+type dsaSignature struct {
+	R, S *big.Int
+}
+
+// Pkcs11Signer is a reference to a Pksc11PrivateKey that implements crypto.Signer.
+type Pkcs11Signer struct {
+	Key *Pkcs11PrivateKey
+}
+
+func (s *Pkcs11Signer) Public() crypto.PublicKey {
+	return s.Key.PublicKey
+}
+
+func (s *Pkcs11Signer) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
+	k := s.Key
+	k.Store.lock.Lock()
+	defer k.Store.lock.Unlock()
+	mechanism := []*pkcs11.Mechanism{
+		pkcs11.NewMechanism(pkcs11.CKM_ECDSA, nil),
+	}
+	if err = k.Store.ctx.SignInit(k.Session, mechanism, k.Object); err != nil {
+		return
+	}
+	var rs []byte
+	if rs, err = k.Store.ctx.Sign(k.Session, digest[:]); err != nil {
+		return
+	}
+	// PKCS#11 returns r || s but crypto.Signer.Sign returns an ASN.1 representation.
+	n := len(rs) / 2
+	var sig dsaSignature
+	sig.R, sig.S = new(big.Int), new(big.Int)
+	sig.R.SetBytes(rs[:n])
+	sig.S.SetBytes(rs[n:])
+	if signature, err = asn1.Marshal(sig); err != nil {
+		return
+	}
+	return
+}

--- a/trustmanager/p11store/p11store.go
+++ b/trustmanager/p11store/p11store.go
@@ -1,0 +1,642 @@
+package p11store
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"github.com/miekg/pkcs11"
+	"github.com/sirupsen/logrus"
+	"github.com/theupdateframework/notary"
+	"github.com/theupdateframework/notary/trustmanager"
+	"github.com/theupdateframework/notary/tuf/data"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Information about a PKCS#11 key that might be available.
+// In principle this information may be invalidated during the life
+// of the process; currently, things just stop working if this happens.
+type pkcs11KeyInfo struct {
+	// Slot containing the token in which the key was last found.
+	slot uint
+
+	// CKA_ID value for key
+	id []byte
+
+	// Notary-specific key information
+	keyInfo trustmanager.KeyInfo
+
+	// Public key
+	publicKey *ecdsa.PublicKey
+
+	// Public key in Notary format
+	tufKey data.TUFKey
+
+	// Notary key ID
+	tufId string
+}
+
+// Mockable interface to PKCS#11 implementation
+type iPKCS11Ctx interface {
+	Initialize() error
+	GetSlotList(tokenPresent bool) ([]uint, error)
+	GetTokenInfo(slotID uint) (pkcs11.TokenInfo, error)
+	OpenSession(slotID uint, flags uint) (pkcs11.SessionHandle, error)
+	CloseSession(sh pkcs11.SessionHandle) error
+	GetSessionInfo(sh pkcs11.SessionHandle) (pkcs11.SessionInfo, error)
+	Login(sh pkcs11.SessionHandle, userType uint, pin string) error
+	GenerateKeyPair(sh pkcs11.SessionHandle, m []*pkcs11.Mechanism, public, private []*pkcs11.Attribute) (pkcs11.ObjectHandle, pkcs11.ObjectHandle, error)
+	DestroyObject(sh pkcs11.SessionHandle, oh pkcs11.ObjectHandle) error
+	GetAttributeValue(sh pkcs11.SessionHandle, o pkcs11.ObjectHandle, a []*pkcs11.Attribute) ([]*pkcs11.Attribute, error)
+	SetAttributeValue(sh pkcs11.SessionHandle, o pkcs11.ObjectHandle, a []*pkcs11.Attribute) error
+	FindObjectsInit(sh pkcs11.SessionHandle, temp []*pkcs11.Attribute) error
+	FindObjects(sh pkcs11.SessionHandle, max int) ([]pkcs11.ObjectHandle, bool, error)
+	FindObjectsFinal(sh pkcs11.SessionHandle) error
+	SignInit(sh pkcs11.SessionHandle, m []*pkcs11.Mechanism, o pkcs11.ObjectHandle) error
+	Sign(sh pkcs11.SessionHandle, message []byte) ([]byte, error)
+}
+
+// A keystore representing a generic PKCS#11 implementation.
+type Pkcs11Store struct {
+	// PKCS#11 library context
+	ctx iPKCS11Ctx
+
+	// Map of key IDs to names
+	keyInfos map[string]pkcs11KeyInfo
+
+	// When keyInfos expires
+	keyInfoExpires time.Time
+
+	// Map of slots to cached RW sessions
+	sessions map[uint]pkcs11.SessionHandle
+
+	// Lock serializing access to this keystore.
+	lock sync.Mutex
+
+	// Function to acquire a passphrase
+	passRetriever notary.PassRetriever
+}
+
+// Errors
+
+// ErrNoProvider indicates no PKCS#11 provider was configured.
+var ErrNoProvider = errors.New("no PKCS#11 provider found")
+
+// ErrNotImplemented is returned by unimplemented methods.
+var ErrNotImplemented = errors.New("PKCS#11 keystore operation not supported")
+
+// ErrTokenNotFound is return when the token for key generation could not be foud.
+var ErrTokenNotFound = errors.New("PKCS#11 token not found")
+
+// Object identifiers
+
+// secp256r1 is the OID for NIST P-256.
+var secp256r1 = []byte{0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07}
+
+// Implementation of trustmanager.KeyStore methods
+
+func (p *Pkcs11Store) AddKey(keyInfo trustmanager.KeyInfo, privKey data.PrivateKey) (err error) {
+	// This key store doesn't support import, only key generation on the HSM.
+	return ErrNotImplemented
+}
+
+func (p *Pkcs11Store) GetKey(keyID string) (privKey data.PrivateKey, role data.RoleName, err error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	var info pkcs11KeyInfo
+	var session pkcs11.SessionHandle
+	var privateObject pkcs11.ObjectHandle
+	if info, session, _, privateObject, err = p.findKey(keyID); err != nil {
+		return
+	}
+	// Extend data.TUFKey with additional information to allow use through PKCS#11
+	// and crypto.Signer.
+	privKey = &Pkcs11PrivateKey{
+		TUFKey:    info.tufKey,
+		Store:     p,
+		Session:   session,
+		Object:    privateObject,
+		PublicKey: info.publicKey,
+	}
+	role = info.keyInfo.Role
+	return
+}
+
+func (p *Pkcs11Store) GetKeyInfo(keyID string) (ki trustmanager.KeyInfo, err error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if err = p.getKeyInfos(); err != nil {
+		return
+	}
+	var ok bool
+	var pki pkcs11KeyInfo
+	if pki, ok = p.keyInfos[keyID]; !ok {
+		err = trustmanager.ErrKeyNotFound{keyID}
+		return
+	}
+	ki = pki.keyInfo
+	return
+}
+
+func (p *Pkcs11Store) ListKeys() (keyInfos map[string]trustmanager.KeyInfo) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	var err error
+	if err = p.getKeyInfos(); err != nil {
+		// No way to return an error so just log it
+		logrus.Errorf("enumerating PKCS#11 keys: %s", err)
+		return
+	}
+	// Extract the information our caller needs
+	keyInfos = map[string]trustmanager.KeyInfo{}
+	for keyID, pkeyInfo := range p.keyInfos {
+		keyInfos[keyID] = pkeyInfo.keyInfo
+	}
+	return
+}
+
+func (p *Pkcs11Store) RemoveKey(keyID string) (err error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	var session pkcs11.SessionHandle
+	var publicObject, privateObject pkcs11.ObjectHandle
+	if _, session, publicObject, privateObject, err = p.findKey(keyID); err != nil {
+		return
+	}
+	if err = p.ctx.DestroyObject(session, privateObject); err != nil {
+		logrus.Errorf("C_DestroyObject: %s", err)
+		return
+	}
+	if err = p.ctx.DestroyObject(session, publicObject); err != nil {
+		logrus.Errorf("C_DestroyObject: %s", err)
+		return
+	}
+	delete(p.keyInfos, keyID)
+	return
+}
+
+func (p *Pkcs11Store) Name() string {
+	return "pkcs11"
+}
+
+func (p *Pkcs11Store) Generate(keyInfo trustmanager.KeyInfo, token, algorithm string) (keyID string, pubKey data.PublicKey, err error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	// Enforce restrictions on what we support
+	if algorithm != data.ECDSAKey {
+		err = fmt.Errorf("algorithm '%s' not supported by PKCS#11 key store", algorithm)
+		return
+	}
+	// Find the token to generate the key on
+	tokenSlot := ^uint(0)
+	if err = p.forEachToken(func(session pkcs11.SessionHandle, slot uint) (err error) {
+		var ti pkcs11.TokenInfo
+		if ti, err = p.ctx.GetTokenInfo(slot); err != nil {
+			logrus.Errorf("C_GetTokenInfo: %s", err)
+			return
+		}
+		if tokenMatches(token, &ti) {
+			tokenSlot = slot
+		}
+		return
+	}); err != nil {
+		return
+	}
+	if tokenSlot == ^uint(0) {
+		err = ErrTokenNotFound
+		return
+	}
+	if err = p.getKeyInfos(); err != nil {
+		return
+	}
+	// Get a RW session on the required slot
+	var session pkcs11.SessionHandle
+	if session, err = p.getSession(tokenSlot); err != nil {
+		return
+	}
+	// Generate a random ID for the key pair
+	idbytes := make([]byte, 12)
+	if _, err = rand.Read(idbytes); err != nil {
+		return
+	}
+	id := base64.RawStdEncoding.EncodeToString(idbytes)
+	// Generate the label
+	label := fmt.Sprintf("%s:%s", keyInfo.Role, keyInfo.Gun)
+	// Key generation parameters
+	publicAttributes := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PUBLIC_KEY),
+		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, pkcs11.CKK_ECDSA),
+		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+		pkcs11.NewAttribute(pkcs11.CKA_VERIFY, true),
+		pkcs11.NewAttribute(pkcs11.CKA_LABEL, label),
+		pkcs11.NewAttribute(pkcs11.CKA_ID, id),
+		pkcs11.NewAttribute(pkcs11.CKA_ECDSA_PARAMS, secp256r1),
+	}
+	privateAttributes := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+		pkcs11.NewAttribute(pkcs11.CKA_SIGN, true),
+		pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, true),
+		pkcs11.NewAttribute(pkcs11.CKA_EXTRACTABLE, false),
+		pkcs11.NewAttribute(pkcs11.CKA_LABEL, label),
+		pkcs11.NewAttribute(pkcs11.CKA_ID, id),
+	}
+	mechanism := []*pkcs11.Mechanism{pkcs11.NewMechanism(pkcs11.CKM_ECDSA_KEY_PAIR_GEN, nil)}
+	// Generate the key
+	var publicObject, privateObject pkcs11.ObjectHandle
+	if publicObject, privateObject, err = p.ctx.GenerateKeyPair(session, mechanism, publicAttributes, privateAttributes); err != nil {
+		logrus.Errorf("C_GenerateKeyPair: %s", err)
+		return
+	}
+	// If something goes wrong before we finished, clean up the key
+	completed := false
+	defer func() {
+		if !completed {
+			p.ctx.DestroyObject(session, publicObject)
+			p.ctx.DestroyObject(session, privateObject)
+		}
+	}()
+	// Construct the key information
+	var info pkcs11KeyInfo
+	if info, err = p.getKeyInfo(session, publicObject); err != nil {
+		return
+	}
+	info.slot = tokenSlot
+	keyID = info.tufId
+	pubKey = &data.ECDSAPublicKey{info.tufKey}
+	// Attempt to set CKA_ID to the TUF id. This isn't completely
+	// necessary but makes life easier for anyone trying to
+	// understand the situation through PKCS#11-native tooling.
+	idAttributes := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_ID, info.tufId),
+	}
+	if err = p.ctx.SetAttributeValue(session, publicObject, idAttributes); err != nil {
+		logrus.Errorf("C_SetAttributeValue for public key: %s", err)
+		return
+	}
+	if err = p.ctx.SetAttributeValue(session, privateObject, idAttributes); err != nil {
+		logrus.Errorf("C_SetAttributeValue for private key: %s", err)
+		return
+	}
+	// Keep id field in step with CKA_ID
+	info.id = []byte(info.tufId)
+	// Save the key information for later
+	p.keyInfos[info.tufId] = info
+	// Don't destroy the key
+	completed = true
+	return
+}
+
+// Other public functions
+
+// Map of provider paths to context structures
+var providers = map[string]iPKCS11Ctx{}
+var providerLock sync.Mutex
+
+// NewPkcs11Store creates a new Pkcs11Store using a specific PKCS#11 provider.
+// If path=="" then ${NOTARY_HSM_LIB} is used.
+func NewPkcs11Store(path string, passRetriever notary.PassRetriever) (p *Pkcs11Store, err error) {
+	providerLock.Lock()
+	defer providerLock.Unlock()
+	if path == "" {
+		// Environment variable name chosen by analogy with VAULT_HSM_LIB.
+		if path = os.Getenv("NOTARY_HSM_LIB"); path == "" {
+			err = ErrNoProvider
+			return
+		}
+	}
+	// We cache initialized provider(s), so that it's harmless to call
+	// NewPkcs11Store more than once in the same process.
+	var ctx iPKCS11Ctx
+	var ok bool
+	if ctx, ok = providers[path]; !ok {
+		// pkcs11 panics if the library doesn't exist, so check that up front.
+		if _, err = os.Stat(path);os.IsNotExist(err) {
+			return
+		}
+		if ctx = pkcs11.New(path); ctx == nil {
+			err = ErrNoProvider
+			return
+		}
+		if err = ctx.Initialize(); err != nil {
+			logrus.Errorf("C_Initialize: %s", err)
+			return
+		}
+		providers[path] = ctx
+	}
+	p = &Pkcs11Store{
+		passRetriever: passRetriever,
+		sessions:      map[uint]pkcs11.SessionHandle{},
+		keyInfos:      nil,
+		ctx:           ctx,
+	}
+	return
+}
+
+// Internal utilies
+
+// forEachToken iterates over all tokens and invokes f with a transient public session.
+// If f returns an error then the iteration stops immediately.
+func (p *Pkcs11Store) forEachToken(f func(session pkcs11.SessionHandle, slot uint) (err error)) (err error) {
+	var slots []uint
+	if slots, err = p.ctx.GetSlotList(true); err != nil {
+		logrus.Errorf("C_GetSlotList: %s", err)
+		return
+	}
+	for _, slot := range slots {
+		var session pkcs11.SessionHandle
+		if session, err = p.ctx.OpenSession(slot, pkcs11.CKF_SERIAL_SESSION); err != nil {
+			if e, ok := err.(pkcs11.Error); ok && e == pkcs11.CKR_TOKEN_NOT_RECOGNIZED {
+				err = nil
+				continue
+			}
+			logrus.Errorf("C_OpenSession slot %v read-only session: %s", slot, err)
+			return
+		}
+		defer p.ctx.CloseSession(session)
+		if err = f(session, slot); err != nil {
+			return
+		}
+	}
+	return
+}
+
+// forEachObject iterates over the objects matching a template and invokes f on each.
+// If f returns an error then the iteration stops immediately.
+func (p *Pkcs11Store) forEachObject(session pkcs11.SessionHandle, attributes []*pkcs11.Attribute, f func(object pkcs11.ObjectHandle) (err error)) (err error) {
+	if err = p.ctx.FindObjectsInit(session, attributes); err != nil {
+		logrus.Errorf("C_FindObjectsInit: %s", err)
+		return
+	}
+	defer p.ctx.FindObjectsFinal(session)
+	for {
+		var objects []pkcs11.ObjectHandle
+		var more bool
+		if objects, more, err = p.ctx.FindObjects(session, 64); err != nil {
+			logrus.Errorf("C_FindObjects: %s", err)
+			return
+		}
+		for _, object := range objects {
+			if err = f(object); err != nil {
+				return
+			}
+		}
+		if !more {
+			break
+		}
+	}
+	return
+}
+
+// getKeyInfos initializes p.keyInfos if it is nil or if it is out of date
+func (p *Pkcs11Store) getKeyInfos() (err error) {
+	if p.keyInfos != nil && time.Now().Before(p.keyInfoExpires) {
+		return
+	}
+	var keyInfos = map[string]pkcs11KeyInfo{}
+	// Search template.
+	// Currently only ECDSA keys are supported, so we restrict the search to that.
+	searchAttributes := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PUBLIC_KEY),
+		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, pkcs11.CKK_ECDSA),
+	}
+	// Search all tokens for usable keys
+	if err = p.forEachToken(func(session pkcs11.SessionHandle, slot uint) (err error) {
+		err = p.forEachObject(session, searchAttributes, func(object pkcs11.ObjectHandle) (err error) {
+			var info pkcs11KeyInfo
+			if info, err = p.getKeyInfo(session, object); err != nil {
+				err = nil // Ignore unusable keys
+				return
+			}
+			info.slot = slot
+			keyInfos[info.tufId] = info
+			return
+		})
+		return
+	}); err != nil {
+		return
+	}
+	p.keyInfos = keyInfos
+	p.keyInfoExpires = time.Now().Add(time.Second)
+	return
+}
+
+// getKeyInfo recovers information about a public key that's already on a token.
+func (p *Pkcs11Store) getKeyInfo(session pkcs11.SessionHandle, object pkcs11.ObjectHandle) (info pkcs11KeyInfo, err error) {
+	// Object attributes that we're interested in.
+	keyAttributes := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_LABEL, 0),
+		pkcs11.NewAttribute(pkcs11.CKA_ID, 0),
+		pkcs11.NewAttribute(pkcs11.CKA_EC_POINT, 0),
+		pkcs11.NewAttribute(pkcs11.CKA_EC_PARAMS, 0),
+	}
+	// Get the key attributes and translate them into Notary's preferred form
+	var attributes []*pkcs11.Attribute
+	if attributes, err = p.ctx.GetAttributeValue(session, object, keyAttributes); err != nil {
+		logrus.Errorf("C_GetAttributeValue: %s", err)
+		return
+	}
+	// Pick out the attributes we care about.
+	// We assume that only the supported key type is supplied.
+	var params, point []byte
+	for _, attribute := range attributes {
+		switch attribute.Type {
+		case pkcs11.CKA_LABEL:
+			bits := strings.SplitN(string(attribute.Value), ":", 2)
+			info.keyInfo.Role = data.RoleName(bits[0])
+			info.keyInfo.Gun = data.GUN(bits[1])
+		case pkcs11.CKA_ID:
+			info.id = attribute.Value
+		case pkcs11.CKA_EC_PARAMS:
+			params = attribute.Value
+		case pkcs11.CKA_EC_POINT:
+			point = attribute.Value
+		}
+	}
+	// Skip keys with missing components
+	if params == nil || point == nil || info.keyInfo.Role == "" {
+		err = errors.New("missing key components")
+		return
+	}
+	// Skip wrong curve
+	if bytes.Compare(secp256r1, params) != 0 {
+		err = errors.New("wrong ECC domain")
+		return
+	}
+	// Parse the public key. PKCS#11 encodes it twice.
+	pointBytes := make([]byte, 0, 65)
+	if _, err = asn1.Unmarshal(point, &pointBytes); err != nil {
+		return
+	}
+	curve := elliptic.P256()
+	x, y := elliptic.Unmarshal(curve, pointBytes)
+	info.publicKey = &ecdsa.PublicKey{curve, x, y}
+	var publicKeyBytes []byte
+	if publicKeyBytes, err = x509.MarshalPKIXPublicKey(info.publicKey); err != nil {
+		return
+	}
+	info.tufKey = data.NewECDSAPublicKey(publicKeyBytes).TUFKey
+	info.tufId = info.tufKey.ID()
+	return
+}
+
+// tokenMatches returns true if tokenInfo matches the specification in token.
+func tokenMatches(token string, tokenInfo *pkcs11.TokenInfo) (matches bool) {
+	bits := strings.SplitN(token, ":", 2)
+	if len(bits) != 2 {
+		return false
+	}
+	var value string
+	key := strings.ToLower(bits[0])
+	if key == "label" {
+		value = tokenInfo.Label
+	} else if key == "serialnumber" {
+		value = tokenInfo.SerialNumber
+	} else {
+		// Give the user a hint about what went wrong
+		logrus.Printf("unrecognized PKCS#11 token selector '%s'", token)
+		return false
+	}
+	// pkcs11 already trimmed trailing whitespace so we can directly compare.
+	return value == bits[1]
+}
+
+// getSession returns a RW session for a slot.
+func (p *Pkcs11Store) getSession(slot uint) (session pkcs11.SessionHandle, err error) {
+	var ok bool
+	// Use the cached session if it exists and is not stale
+	if session, ok = p.sessions[slot]; ok {
+		if _, err = p.ctx.GetSessionInfo(session); err == nil {
+			return
+		}
+		// Session exists but is stale
+		delete(p.sessions, slot)
+		if err = p.ctx.CloseSession(session); err != nil {
+			logrus.Errorf("C_CloseSession: %v (ignored)", err)
+		}
+	}
+	if session, err = p.ctx.OpenSession(slot, pkcs11.CKF_SERIAL_SESSION|pkcs11.CKF_RW_SESSION); err != nil {
+		logrus.Errorf("C_OpenSession slot %v rw session: %s", slot, err)
+		return
+	}
+	closeSession := session
+	defer func() {
+		if closeSession != 0 {
+			p.ctx.CloseSession(closeSession)
+		}
+	}()
+	// Construct a 'keyName' based on the token description.
+	// Some tokens return empty strings for this field or that
+	// so exclude them.
+	var ti pkcs11.TokenInfo
+	if ti, err = p.ctx.GetTokenInfo(slot); err != nil {
+		logrus.Errorf("C_GetTokenInfo: %s", err)
+		return
+	}
+	tokenBits := make([]string, 0, 4)
+	if ti.ManufacturerID != "" {
+		tokenBits = append(tokenBits, ti.ManufacturerID)
+	}
+	if ti.Model != "" {
+		tokenBits = append(tokenBits, ti.Model)
+	}
+	if ti.Label != "" {
+		tokenBits = append(tokenBits, ti.Label)
+	}
+	if ti.SerialNumber != "" {
+		tokenBits = append(tokenBits, fmt.Sprintf("(%s)", ti.SerialNumber))
+	}
+	tokenName := strings.Join(tokenBits, " ")
+	if ti.Flags & pkcs11.CKF_LOGIN_REQUIRED != 0 {
+		// Acquire the passphrase
+		var passphrase string
+		var giveup bool
+		for attempts := 0; ; attempts++ {
+			if passphrase, giveup, err = p.passRetriever(tokenName, "pkcs11", false, attempts); err != nil {
+				return
+			}
+			if giveup || attempts > 10 {
+				err = trustmanager.ErrPasswordInvalid{}
+				return
+			}
+			err = p.ctx.Login(session, pkcs11.CKU_USER, passphrase)
+			if err == nil { // Success
+				break
+			}
+			if e, ok := err.(pkcs11.Error); ok {
+				if e == pkcs11.CKR_PIN_INCORRECT { // Passphrase incorrect
+					continue
+				}
+			}
+			logrus.Errorf("C_Login: %s", err)
+			return // Some more serious error
+		}
+	}
+	// Cache the session for next time
+	p.sessions[slot] = session
+	closeSession = 0 // don't close
+	return
+}
+
+// findKey finds a key and returns the object handles and a RW session for them.
+func (p *Pkcs11Store) findKey(keyID string) (info pkcs11KeyInfo, session pkcs11.SessionHandle, publicObject, privateObject pkcs11.ObjectHandle, err error) {
+	if err = p.getKeyInfos(); err != nil {
+		return
+	}
+	var ok bool
+	if info, ok = p.keyInfos[keyID]; !ok {
+		err = trustmanager.ErrKeyNotFound{keyID}
+		return
+	}
+	// Get a RW session on the required slot
+	if session, err = p.getSession(info.slot); err != nil {
+		return
+	}
+	// Find the private key
+	searchAttributes := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+		pkcs11.NewAttribute(pkcs11.CKA_ID, info.id),
+	}
+	keyAttributes := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, 0),
+	}
+	privateAttribute := pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PRIVATE_KEY)
+	if err = p.forEachObject(session, searchAttributes, func(object pkcs11.ObjectHandle) (err error) {
+		// Get the key attributes and translate them into Notary's preferred form
+		var attributes []*pkcs11.Attribute
+		if attributes, err = p.ctx.GetAttributeValue(session, object, keyAttributes); err != nil {
+			logrus.Errorf("C_GetAttributeValue: %s", err)
+			return
+		}
+		if bytes.Compare(attributes[0].Value, privateAttribute.Value) == 0 {
+			if privateObject != 0 {
+				err = fmt.Errorf("multiple PKSC#11 private key objects for %s", keyID)
+				return
+			}
+			privateObject = object
+		} else {
+			if publicObject != 0 {
+				err = fmt.Errorf("multiple PKSC#11 public key objects for %s", keyID)
+				return
+			}
+			publicObject = object
+		}
+		return
+	}); err != nil {
+		return
+	}
+	if privateObject == 0 || publicObject == 0 {
+		logrus.Errorf("missing PKCS#11 key object for %s", keyID)
+		err = trustmanager.ErrKeyNotFound{keyID}
+		return
+	}
+	return
+}

--- a/trustmanager/p11store/p11store_test.go
+++ b/trustmanager/p11store/p11store_test.go
@@ -1,0 +1,394 @@
+package p11store
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/asn1"
+	"github.com/miekg/pkcs11"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/theupdateframework/notary/trustmanager"
+	"github.com/theupdateframework/notary/tuf/data"
+	"math/big"
+	"testing"
+)
+
+// mockProvider behaves somewhat like an nShield HSM
+type mockProvider struct {
+}
+
+// Data and state for the mock HSM
+
+// tokenInfos contains example C_GetTokenInfo output
+var tokenInfos = map[uint]pkcs11.TokenInfo{
+	492971157: pkcs11.TokenInfo{Label: "accelerator", ManufacturerID: "nCipher Corp. Ltd", Model: "", SerialNumber: "6262-799D-D906", Flags: 0x201, MaxSessionCount: 0x0, SessionCount: 0x1, MaxRwSessionCount: 0x0, RwSessionCount: 0x0, MaxPinLen: 0x100, MinPinLen: 0x0, TotalPublicMemory: 0xffffffffffffffff, FreePublicMemory: 0xffffffffffffffff, TotalPrivateMemory: 0xffffffffffffffff, FreePrivateMemory: 0xffffffffffffffff, HardwareVersion: pkcs11.Version{Major: 0x9, Minor: 0x63}, FirmwareVersion: pkcs11.Version{Major: 0xc, Minor: 0x32}, UTCTime: ""},
+	492971158: pkcs11.TokenInfo{Label: "ocs2", ManufacturerID: "nCipher Corp. Ltd", Model: "", SerialNumber: "3d39ca03182939d8", Flags: 0x20d, MaxSessionCount: 0x0, SessionCount: 0x1, MaxRwSessionCount: 0x0, RwSessionCount: 0x0, MaxPinLen: 0x100, MinPinLen: 0x0, TotalPublicMemory: 0xffffffffffffffff, FreePublicMemory: 0xffffffffffffffff, TotalPrivateMemory: 0xffffffffffffffff, FreePrivateMemory: 0xffffffffffffffff, HardwareVersion: pkcs11.Version{Major: 0x9, Minor: 0x63}, FirmwareVersion: pkcs11.Version{Major: 0xc, Minor: 0x32}, UTCTime: ""},
+	492971159: pkcs11.TokenInfo{Label: "accelerator", ManufacturerID: "nCipher Corp. Ltd", Model: "", SerialNumber: "5E69-A92C-7097", Flags: 0x201, MaxSessionCount: 0x0, SessionCount: 0x1, MaxRwSessionCount: 0x0, RwSessionCount: 0x0, MaxPinLen: 0x100, MinPinLen: 0x0, TotalPublicMemory: 0xffffffffffffffff, FreePublicMemory: 0xffffffffffffffff, TotalPrivateMemory: 0xffffffffffffffff, FreePrivateMemory: 0xffffffffffffffff, HardwareVersion: pkcs11.Version{Major: 0x9, Minor: 0x63}, FirmwareVersion: pkcs11.Version{Major: 0xc, Minor: 0x32}, UTCTime: ""},
+	492971160: pkcs11.TokenInfo{Label: "ocs1", ManufacturerID: "nCipher Corp. Ltd", Model: "", SerialNumber: "7e585d361027d0e6", Flags: 0x20d, MaxSessionCount: 0x0, SessionCount: 0x1, MaxRwSessionCount: 0x0, RwSessionCount: 0x0, MaxPinLen: 0x100, MinPinLen: 0x0, TotalPublicMemory: 0xffffffffffffffff, FreePublicMemory: 0xffffffffffffffff, TotalPrivateMemory: 0xffffffffffffffff, FreePrivateMemory: 0xffffffffffffffff, HardwareVersion: pkcs11.Version{Major: 0x9, Minor: 0x63}, FirmwareVersion: pkcs11.Version{Major: 0xc, Minor: 0x32}, UTCTime: ""},
+}
+
+// mockClassPublicKey is the attribute value for CKO_PUBLIC_KEY.
+// (The format is platform-dependent so it's convenient to compare
+// byte strings rather than turn back into an integer value.)
+var mockClassPublicKey = pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PUBLIC_KEY).Value
+
+// mockClassPublicKey is the attribute value for CKO_PRIVATE_KEY.
+var mockClassPrivateKey = pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PRIVATE_KEY).Value
+
+// sessionInfo holds information about a synthetic PKCS#11 session handle.
+type sessionInfo struct {
+	// Slot that session was opened to
+	slot uint
+
+	// Flags used when opening session
+	flags uint
+
+	// Session state
+	state uint
+
+	// Objects to be returned by C_FindObjects
+	objects []pkcs11.ObjectHandle
+
+	// Key to be used by C_Sign
+	signer *ecdsa.PrivateKey
+}
+
+// sessionCounter is the last session handle allocated.
+var sessionCounter = pkcs11.SessionHandle(0)
+
+// sessions maps session handles to session information.
+var sessions = map[pkcs11.SessionHandle]*sessionInfo{}
+
+// objectInfo holds information about a synthetic PKCS#11 object.
+type objectInfo struct {
+	// CKA_LABEL value
+	label []byte
+
+	// CKA_ID value
+	id []byte
+
+	// CKA_CLASS value
+	class []byte
+
+	// Encoded public key (if CKA_CLASS=CKO_PUBLIC_KEY)
+	pubder []byte
+
+	// Signing key (if CKA_CLASS=CKO_PRIVATE_KEY)
+	privkey *ecdsa.PrivateKey
+}
+
+// objectCounter is the last object handle allocated
+var objectCounter = pkcs11.ObjectHandle(0)
+
+// ovjects maps object handles to object information.
+var objects = map[pkcs11.ObjectHandle]*objectInfo{}
+
+// Mock methods
+
+func (m *mockProvider) Initialize() (err error) {
+	return
+}
+
+func (m *mockProvider) GetSlotList(tokenPresent bool) (slots []uint, err error) {
+	slots = make([]uint, 0, len(tokenInfos))
+	for slot, _ := range tokenInfos {
+		slots = append(slots, slot)
+	}
+	return
+}
+
+func (m *mockProvider) GetTokenInfo(slotID uint) (ti pkcs11.TokenInfo, err error) {
+	ti = tokenInfos[slotID]
+	return
+}
+
+func (m *mockProvider) OpenSession(slotID uint, flags uint) (sh pkcs11.SessionHandle, err error) {
+	sessionCounter += 1
+	sessions[sessionCounter] = &sessionInfo{slotID, flags, 0, nil, nil}
+	sh = sessionCounter
+	return
+}
+
+func (m *mockProvider) CloseSession(sh pkcs11.SessionHandle) (err error) {
+	if _, ok := sessions[sh]; !ok {
+		err = pkcs11.Error(pkcs11.CKR_SESSION_HANDLE_INVALID)
+		return
+	}
+	delete(sessions, sh)
+	return
+}
+
+func (m *mockProvider) GetSessionInfo(sh pkcs11.SessionHandle) (si pkcs11.SessionInfo, err error) {
+	var s *sessionInfo
+	var ok bool
+	if s, ok = sessions[sh]; !ok {
+		err = pkcs11.Error(pkcs11.CKR_SESSION_HANDLE_INVALID)
+		return
+	}
+	si.SlotID = s.slot
+	si.State = s.state
+	si.Flags = s.flags
+	si.DeviceError = 0
+	return
+}
+
+func (m *mockProvider) Login(sh pkcs11.SessionHandle, userType uint, pin string) (err error) {
+	var expectedPassword string
+	switch sessions[sh].slot {
+	case 492971158:
+		expectedPassword = "test"
+	case 492971160:
+		expectedPassword = "test2"
+	}
+	if pin != expectedPassword {
+		err = pkcs11.Error(pkcs11.CKR_PIN_INCORRECT)
+		return
+	}
+	sessions[sh].state = 3
+	return
+}
+
+func (m *mockProvider) GenerateKeyPair(sh pkcs11.SessionHandle, mech []*pkcs11.Mechanism, public, private []*pkcs11.Attribute) (pubObj pkcs11.ObjectHandle, privObj pkcs11.ObjectHandle, err error) {
+	var label []byte
+	var id []byte
+	for _, a := range public {
+		switch a.Type {
+		case pkcs11.CKA_LABEL:
+			label = a.Value
+		case pkcs11.CKA_ID:
+			id = a.Value
+		}
+	}
+	var k *ecdsa.PrivateKey
+	if k, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader); err != nil {
+		return
+	}
+	pubDer := elliptic.Marshal(elliptic.P256(), k.PublicKey.X, k.PublicKey.Y)
+	if pubDer, err = asn1.Marshal(pubDer); err != nil {
+		return
+	}
+	objectCounter += 1
+	pubObj = objectCounter
+	objects[pubObj] = &objectInfo{label, id, mockClassPublicKey, pubDer, nil}
+	objectCounter += 1
+	privObj = objectCounter
+	objects[privObj] = &objectInfo{label, id, mockClassPrivateKey, nil, k}
+	return
+}
+
+func (m *mockProvider) DestroyObject(sh pkcs11.SessionHandle, oh pkcs11.ObjectHandle) (err error) {
+	if _, ok := objects[oh]; !ok {
+		err = pkcs11.Error(pkcs11.CKR_OBJECT_HANDLE_INVALID)
+		return
+	}
+	delete(objects, oh)
+	return
+}
+
+func (m *mockProvider) GetAttributeValue(sh pkcs11.SessionHandle, oh pkcs11.ObjectHandle, attrs []*pkcs11.Attribute) (result []*pkcs11.Attribute, err error) {
+	oinfo := objects[oh]
+	for _, a := range attrs {
+		var value []byte
+		switch a.Type {
+		case pkcs11.CKA_LABEL:
+			value = oinfo.label
+		case pkcs11.CKA_ID:
+			value = oinfo.id
+		case pkcs11.CKA_EC_POINT:
+			value = oinfo.pubder
+		case pkcs11.CKA_EC_PARAMS:
+			value = secp256r1
+		case pkcs11.CKA_CLASS:
+			value = oinfo.class
+		default:
+			panic("not implemented")
+		}
+		result = append(result, pkcs11.NewAttribute(a.Type, value))
+	}
+	return
+}
+
+func (m *mockProvider) SetAttributeValue(sh pkcs11.SessionHandle, oh pkcs11.ObjectHandle, attrs []*pkcs11.Attribute) (err error) {
+	oinfo := objects[oh]
+	for _, a := range attrs {
+		switch a.Type {
+		case pkcs11.CKA_LABEL:
+			oinfo.label = a.Value
+		case pkcs11.CKA_ID:
+			oinfo.id = a.Value
+		case pkcs11.CKA_EC_POINT:
+			oinfo.pubder = a.Value
+		case pkcs11.CKA_CLASS:
+			oinfo.class = a.Value
+		default:
+			panic("not implemented")
+		}
+	}
+	return
+}
+
+func (m *mockProvider) FindObjectsInit(sh pkcs11.SessionHandle, temp []*pkcs11.Attribute) (err error) {
+	results := make([]pkcs11.ObjectHandle, 0)
+	for oh, oinfo := range objects {
+		objectMatches := true
+		for _, a := range temp {
+			var attributeMatches bool
+			switch a.Type {
+			case pkcs11.CKA_ID:
+				attributeMatches = (bytes.Compare(a.Value, oinfo.id) == 0)
+			case pkcs11.CKA_LABEL:
+				attributeMatches = (bytes.Compare(a.Value, oinfo.label) == 0)
+			case pkcs11.CKA_TOKEN:
+				attributeMatches = true
+			case pkcs11.CKA_CLASS:
+				attributeMatches = (bytes.Compare(a.Value, oinfo.class) == 0)
+			case pkcs11.CKA_KEY_TYPE:
+				attributeMatches = true
+			default:
+				panic("not implemented")
+			}
+			if !attributeMatches {
+				objectMatches = false
+				break
+			}
+		}
+		if objectMatches {
+			results = append(results, oh)
+		}
+	}
+	sessions[sh].objects = results
+	return
+}
+
+func (m *mockProvider) FindObjects(sh pkcs11.SessionHandle, max int) (objects []pkcs11.ObjectHandle, more bool, err error) {
+	objects = sessions[sh].objects
+	more = false
+	return
+}
+
+func (m *mockProvider) FindObjectsFinal(sh pkcs11.SessionHandle) (err error) {
+	sessions[sh].objects = nil
+	return
+}
+
+func (m *mockProvider) SignInit(sh pkcs11.SessionHandle, mech []*pkcs11.Mechanism, oh pkcs11.ObjectHandle) (err error) {
+	if mech[0].Mechanism != pkcs11.CKM_ECDSA {
+		err = pkcs11.Error(pkcs11.CKR_MECHANISM_INVALID)
+		return
+	}
+	sessions[sh].signer = objects[oh].privkey
+	return
+}
+
+func (m *mockProvider) Sign(sh pkcs11.SessionHandle, message []byte) (sig []byte, err error) {
+	var r, s *big.Int
+	if r, s, err = ecdsa.Sign(rand.Reader, sessions[sh].signer, message); err != nil {
+		return
+	}
+	rbytes := r.Bytes()
+	rbytes = append(make([]byte, 32-len(rbytes)), rbytes...)
+	sbytes := s.Bytes()
+	sbytes = append(make([]byte, 32-len(sbytes)), sbytes...)
+	sig = append(rbytes, sbytes...)
+	return
+}
+
+// getTestStore returns a Pkcs11Store using a mock PKCS#11 provider.
+func getTestStore(t *testing.T, pin string) (p *Pkcs11Store) {
+	p = &Pkcs11Store{
+		ctx:      &mockProvider{},
+		sessions: map[uint]pkcs11.SessionHandle{},
+		keyInfos: map[string]pkcs11KeyInfo{},
+		passRetriever: func(keyName, alias string, createNew bool, attempts int) (passphrase string, giveup bool, err error) {
+			passphrase = pin
+			return
+		},
+	}
+	return
+}
+
+func TestPkcs11Store(t *testing.T) {
+	store := getTestStore(t, "test2")
+	// Store expected to be empty at startup
+	keyInfos := store.ListKeys()
+	require.Empty(t, keyInfos)
+	// Key generation must work
+	keyID, pubKeyGen, err := store.Generate(trustmanager.KeyInfo{"anything", "root"}, "label:ocs1", "ecdsa")
+	require.NoError(t, err)
+	// Key identifiers must not be trivial
+	assert.True(t, len(keyID) > 0)
+	// Key must show up in key list
+	keyInfos = store.ListKeys()
+	keyInfo, ok := keyInfos[keyID]
+	require.True(t, ok)
+	assert.Equal(t, data.RoleName("root"), keyInfo.Role)
+	assert.Equal(t, data.GUN("anything"), keyInfo.Gun)
+	// Must be able to retrieve key
+	var privKey data.PrivateKey
+	var role data.RoleName
+	privKey, role, err = store.GetKey(keyID)
+	require.NoError(t, err)
+	assert.Equal(t, data.RoleName("root"), role)
+	pubKey := privKey.CryptoSigner().Public().(*ecdsa.PublicKey)
+	// Must be able to sign. data.PrivateKey.Sign is message -> r||s.
+	message := []byte("test message")
+	digest := sha256.Sum256(message)
+	var sig []byte
+	sig, err = privKey.Sign(rand.Reader, message, nil)
+	require.NoError(t, err)
+	// Signature must verify
+	var rs dsaSignature
+	rs.R = big.NewInt(0)
+	rs.S = big.NewInt(0)
+	rs.R.SetBytes(sig[:len(sig)/2])
+	rs.S.SetBytes(sig[len(sig)/2:])
+	assert.True(t, ecdsa.Verify(pubKey, digest[:], rs.R, rs.S))
+	// Must be able to sign via crypto.Signer, which is digest -> DER.
+	sig, err = privKey.CryptoSigner().Sign(rand.Reader, digest[:], nil)
+	require.NoError(t, err)
+	// Signature must verify
+	rs.R = nil
+	rs.S = nil
+	_, err = asn1.Unmarshal(sig, &rs)
+	require.NoError(t, err)
+	assert.True(t, ecdsa.Verify(pubKey, digest[:], rs.R, rs.S))
+	// Remove the key
+	assert.NoError(t, store.RemoveKey(keyID))
+	// It must be gone from the key list
+	keyInfos = store.ListKeys()
+	_, ok = keyInfos[keyID]
+	require.False(t, ok)
+	// It must not be findable
+	_, _, err = store.GetKey(keyID)
+	require.NotNil(t, err)
+	// Consistency check between public key from generation and signer
+	var pubKeyDecoded crypto.PublicKey
+	pubKeyDecoded, err = x509.ParsePKIXPublicKey(pubKeyGen.Public())
+	require.NoError(t, err)
+	pubKeyEcdsa := pubKeyDecoded.(*ecdsa.PublicKey)
+	assert.EqualValues(t, pubKeyEcdsa, pubKey)
+}
+
+func TestPkcs11Store_Negative(t *testing.T) {
+	var err error
+	store := getTestStore(t, "test2")
+	// Nonexistent keys mustn't be findable
+	_, err = store.GetKeyInfo("9b5d4d02a77f2b4d645bff290d753f641571c0dfa09c7581d6019b67dec2ad45")
+	require.NotNil(t, err)
+	_, _, err = store.GetKey("9b5d4d02a77f2b4d645bff290d753f641571c0dfa09c7581d6019b67dec2ad45")
+	require.NotNil(t, err)
+	// Nonexistent keys mustn't be removable
+	assert.NotNil(t, store.RemoveKey("9b5d4d02a77f2b4d645bff290d753f641571c0dfa09c7581d6019b67dec2ad45"))
+	// Import isn't supported
+	err = store.AddKey(trustmanager.KeyInfo{}, nil)
+	assert.NotNil(t, err)
+	// Wrong passphrase
+	storeWrongPP := getTestStore(t, "open sesame")
+	_, _, err = storeWrongPP.Generate(trustmanager.KeyInfo{"anything", "root"}, "label:ocs1", "ecdsa")
+	assert.NotNil(t, err)
+}

--- a/trustmanager/p11store/pkcs11.md
+++ b/trustmanager/p11store/pkcs11.md
@@ -23,6 +23,12 @@ instead.
 
 ## Generating Keys
 
+`notary init` does not generate HSM-protected keys.
+Instead you must generate the required keys in advance with `notary key generate`.
+This can be done for the root, targets and snapshot keys.
+
+### Root Key
+
 Here I assume a token with a label of `ocs1`.
 You can also specify `serialNumber:7e585d361027d0e6`.
 
@@ -30,26 +36,32 @@ You can also specify `serialNumber:7e585d361027d0e6`.
     Enter the passphrase for the PKCS#11 token 'nCipher Corp. Ltd ocs1 (7e585d361027d0e6)':
     Generated new ecdsa root key with keyID: ea90ae746cbb336030db3e8715218ce4dcd0411e65c37c80bf78959ff1774dca
 
-The key should be visible in the key list:
+### Targets Key
+
+    $ notary key generate -K pkcs11 -T label:ocs1 -r targets -g example.com/nshield
+    Enter the passphrase for the PKCS#11 token 'nCipher Corp. Ltd ocs1 (7e585d361027d0e6)':
+    Generated new ecdsa targets key with keyID: 930e06d6c0f2e0c0e1a45eb403cf573d7d934f44cbd41adec784ead07b7451e5
+
+### Outcome
+
+The keys should be visible in the key list:
 
     $ notary key list
-    
-    ROLE    GUN    KEY ID                                                              LOCATION
-    ----    ---    ------                                                              --------
-    root           ea90ae746cbb336030db3e8715218ce4dcd0411e65c37c80bf78959ff1774dca    pkcs11
+
+    ROLE       GUN                    KEY ID                                                              LOCATION
+    ----       ---                    ------                                                              --------
+    root                              ea90ae746cbb336030db3e8715218ce4dcd0411e65c37c80bf78959ff1774dca    pkcs11
+    targets    example.com/nshield    930e06d6c0f2e0c0e1a45eb403cf573d7d934f44cbd41adec784ead07b7451e5    pkcs11
 
 If you don't set `NOTARY_HSM_LIB` appropriately then the key just disappears:
 
     $ NOTARY_HSM_LIB="" notary key list -v
-    
-    No signing keys found.
 
-At the time of writing only the `targets` role is supported,
-but my aspiration is to expand this.
+    No signing keys found.
 
 ## Initializing Collections
 
-`notary init` will automatically pick up a key in the root role if it exists.
+`notary init` will automatically pick up a key in the root, targets and snapshot roles if they exist.
 
     $ notary init example.com/collection
     Root key found, using: ea90ae746cbb336030db3e8715218ce4dcd0411e65c37c80bf78959ff1774dca
@@ -107,6 +119,10 @@ For example:
 
 ## Rotating Keys
 
+Unlike `notary init`, `notary key rotate` is capable of generating HSM-protected keys.
+
+### Rotating the root key
+
     $ notary key rotate -K pkcs11 -T label:ocs1 -v example.com/collection root
     Warning: you are about to rotate your root key.
 
@@ -115,6 +131,12 @@ For example:
     Enter the passphrase for the PKCS#11 token 'nCipher Corp. Ltd ocs1 (7e585d361027d0e6)':
     Enter passphrase for snapshot key with ID 783c289:
     Successfully rotated root key for repository example.com/nshield
+
+### Rotating the targets key
+
+    $ notary key rotate -K pkcs11 -T label:ocs1 -v example.com/nshield targets
+    Enter the passphrase for the PKCS#11 token 'nCipher Corp. Ltd ocs1 (7e585d361027d0e6)':
+    Successfully rotated targets key for repository example.com/nshield
 
 ## Removing Keys
 

--- a/trustmanager/p11store/pkcs11.md
+++ b/trustmanager/p11store/pkcs11.md
@@ -1,0 +1,146 @@
+# Using Notary with PKCS#11
+
+## Overview
+
+The `pkcs11` key store is always built into Notary.
+No build-time configuration is required.
+
+This key store appears (by default) last in the list of supported key stores.
+So by default keys will be created in software and no HSM used.
+To enable use of an HSM, the new `--keystore` and `--token` arguments must be used
+when generating the key.
+
+This key store has been tested with nShield and SoftHSM.
+
+## Device Configuration
+
+You must tell Notary which PKCS#11 provider to use via the environment.
+
+    $ export NOTARY_HSM_LIB=/opt/nfast/toolkits/pkcs11/libcknfast.so
+
+For other devices, specify the path to their PKCS#11 implementation
+instead.
+
+## Generating Keys
+
+Here I assume a token with a label of `ocs1`.
+You can also specify `serialNumber:7e585d361027d0e6`.
+
+    $ notary key generate -K pkcs11 -T label:ocs1 -r root -v
+    Enter the passphrase for the PKCS#11 token 'nCipher Corp. Ltd ocs1 (7e585d361027d0e6)':
+    Generated new ecdsa root key with keyID: ea90ae746cbb336030db3e8715218ce4dcd0411e65c37c80bf78959ff1774dca
+
+The key should be visible in the key list:
+
+    $ notary key list
+    
+    ROLE    GUN    KEY ID                                                              LOCATION
+    ----    ---    ------                                                              --------
+    root           ea90ae746cbb336030db3e8715218ce4dcd0411e65c37c80bf78959ff1774dca    pkcs11
+
+If you don't set `NOTARY_HSM_LIB` appropriately then the key just disappears:
+
+    $ NOTARY_HSM_LIB="" notary key list -v
+    
+    No signing keys found.
+
+At the time of writing only the `targets` role is supported,
+but my aspiration is to expand this.
+
+## Initializing Collections
+
+`notary init` will automatically pick up a key in the root role if it exists.
+
+    $ notary init example.com/collection
+    Root key found, using: ea90ae746cbb336030db3e8715218ce4dcd0411e65c37c80bf78959ff1774dca
+    Enter the passphrase for the PKCS#11 token 'nCipher Corp. Ltd ocs1 (7e585d361027d0e6)':
+    Enter passphrase for new targets key with ID 95bf542:
+    Repeat passphrase for new targets key with ID 95bf542:
+    Enter passphrase for new snapshot key with ID 783c289:
+    Repeat passphrase for new snapshot key with ID 783c289:
+
+## Identifying Keys
+
+The `pkcs11` key store encodes the role and GUN into the `CKA_LABEL` attribute,
+and the Notary key ID into the `CKA_ID` attribute.
+For example:
+
+    CKA_CLASS CKO_PUBLIC_KEY
+    CKA_TOKEN true
+    CKA_PRIVATE false
+    CKA_MODIFIABLE true
+    CKA_LABEL "root:"
+    CKA_NFKM_APPNAME "pkcs11"
+    CKA_NFKM_ID "uc7e585d361027d0e607963663cde62b950dd1a689-18831841f6a00c2501cd2e699df11a33aaddff98"
+    CKA_NFKM_HASH length 20
+      { F0FC742D 4C915568 1B804FCB 40EB6972 CF751840 }
+    CKA_KEY_TYPE CKK_EC
+    CKA_ID length 64
+      { 65613930 61653734 36636262 33333630 33306462
+        33653837 31353231 38636534 64636430 34313165
+        36356333 37633830 62663738 39353966 66313737
+        34646361 }
+      as string "ea90ae746cbb336030db3e8715218ce4dcd0411e65c37c80bf78959ff1774dca"
+    CKA_ISSUER length 0
+    CKA_SERIAL_NUMBER length 0
+    CKA_DERIVE false
+    CKA_LOCAL true
+    CKA_START_DATE 0000 00 00
+    CKA_END_DATE 0000 00 00
+    CKA_KEY_GEN_MECHANISM CKM_EC_KEY_PAIR_GEN
+    CKA_ALLOWED_MECHANISMS: ANY
+    CKA_SUBJECT length 0
+    CKA_ENCRYPT false
+    CKA_VERIFY true
+    CKA_VERIFY_RECOVER false
+    CKA_WRAP false
+    CKA_TRUSTED false
+    CKA_EC_PARAMS length 10 (80 bits)
+      { 0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07 }
+    CKA_EC_POINT length 67 (536 bits)
+      { 0x04, 0x41, 0x04, 0xBE, 0xDC, 0xBD, 0x5D, 0x46, 0x94, 0xC5, 0x0A, 0xF0,
+        0x3E, 0xF3, 0x84, 0x74, 0x52, 0x62, 0x58, 0x4A, 0x60, 0xE0, 0x3B, 0x00,
+        0xF4, 0xF9, 0xF6, 0x72, 0x98, 0x59, 0xF2, 0xAB, 0xD5, 0x8C, 0xD3, 0x99,
+        0xBC, 0x81, 0x3E, 0xE1, 0xBD, 0xDC, 0x71, 0x0E, 0xCF, 0x07, 0xCE, 0xF2,
+        0x92, 0xEF, 0x0E, 0x9E, 0x1D, 0x66, 0x0C, 0xC3, 0x93, 0xDB, 0x34, 0x7F,
+        0x7F, 0xB3, 0x05, 0x7B, 0xE4, 0xEE, 0x2E }
+
+## Rotating Keys
+
+    $ notary key rotate -K pkcs11 -T label:ocs1 -v example.com/collection root
+    Warning: you are about to rotate your root key.
+
+    You must use your old key to sign this root rotation.
+    Are you sure you want to proceed?  (yes/no)
+    Enter the passphrase for the PKCS#11 token 'nCipher Corp. Ltd ocs1 (7e585d361027d0e6)':
+    Enter passphrase for snapshot key with ID 783c289:
+    Successfully rotated root key for repository example.com/nshield
+
+## Removing Keys
+
+    $ notary key remove ea90ae746cbb336030db3e8715218ce4dcd0411e65c37c80bf78959ff1774dca
+    
+    Are you sure you want to remove ea90ae746cbb336030db3e8715218ce4dcd0411e65c37c80bf78959ff1774dca (role root) from pkcs11?  (yes/no)  yes
+    Enter the passphrase for the PKCS#11 token 'nCipher Corp. Ltd ocs1 (7e585d361027d0e6)':
+    
+    Deleted ea90ae746cbb336030db3e8715218ce4dcd0411e65c37c80bf78959ff1774dca (role root) from pkcs11.
+
+You can also remove it with the HSM's native tools
+if you can correctly identify it.
+
+# Developer Information
+
+## Testing
+
+Currently Notary's tests can fail if `NOTARY_HSM_LIB` is set,
+because the expectation of an empty initial set of keys is violated
+by any keys available on the HSM.
+
+## Issues
+
+* `notary key passwd` panics if you try to change the password
+on a key held in the `pkcs11` keystore.
+The reason is that the `Private()` method lacks any other way to signal an error.
+* `notary key export` does not export keys from the `pkcs11` keystore.
+This is consistent with its description as exporting from “local keystores”
+but may be confusing nevertheless.

--- a/trustmanager/yubikey/yubikeystore.go
+++ b/trustmanager/yubikey/yubikeystore.go
@@ -805,6 +805,28 @@ func (s *YubiStore) GetKeyInfo(keyID string) (trustmanager.KeyInfo, error) {
 	return trustmanager.KeyInfo{}, fmt.Errorf("Not yet implemented")
 }
 
+// Generate generates a key and adds it to the keystore.
+func (s *YubiStore) Generate(keyInfo trustmanager.KeyInfo, token, algorithm string) (keyID string, pubKey data.PublicKey, err error) {
+	// Only specialized keystores support multiple tokens.
+	if token != "" {
+		err = fmt.Errorf("key store %s does not support multiple tokens", s.Name())
+		return
+	}
+	// Generate the key
+	var privKey data.PrivateKey
+	if privKey, err = utils.GenerateKey(algorithm); err != nil {
+		return
+	}
+	// Compute the public key
+	pubKey = data.PublicKeyFromPrivate(privKey)
+	// Add it to the key store
+	if err = s.AddKey(keyInfo, privKey); err == nil {
+		return
+	}
+	// Success
+	return
+}
+
 func cleanup(ctx IPKCS11Ctx, session pkcs11.SessionHandle) {
 	err := ctx.CloseSession(session)
 	if err != nil {


### PR DESCRIPTION
This PR adds a new `pkcs11` key store. I have tested with nShield and SoftHSM. Usage is described in `trustmanager/p11store/pkcs11.md`.

# Overview

- The new key store appears last in the list so will not be used by default.
- New command-line options control key generation using a PKCS#11 token.
- It supports root, targets, timestamp and snapshot keys.
- No build-time configuration is required.

# Discussion

I originally raised this project on [one of the other PKCS#11-related issues](https://github.com/theupdateframework/notary/issues/1289), with my [original plan here](https://gist.github.com/nfewx/839327740b1355f6fd2c9d36aa790190
).

The only discussion arising was that Florian suggested supporting multiple classes of HSM concurrently. I've not done this since it's not a use case I have, but I'd be happy to retest against nShield if someone needs this idea enough to implement it.

In the end I didn't attempt to share code with the existing PKCS#11 implementation. I felt that the differing assumptions about (for example) the number of slots on the token and the interpretation of `CKA_ID` made this impractical.

# Availability

Unfortunately I will have poor availability in the next week or two (i.e. early July 2018) - so I apologise in advance if I'm slow to respond to any feedback.