### PR TITLE
Notary client refactor - simpler reader interface

### DIFF
--- a/client/backwards_compatibility_test.go
+++ b/client/backwards_compatibility_test.go
@@ -239,7 +239,7 @@ func Test0Dot1RepoFormat(t *testing.T) {
 	// and we can download the snapshot
 	require.NoError(t, repo.RotateKey(data.CanonicalSnapshotRole, true, nil))
 	require.NoError(t, repo.Publish())
-	err = repo.Update(false)
+	err = repo.updateTUF(false)
 	require.NoError(t, err)
 }
 
@@ -307,7 +307,7 @@ func Test0Dot3RepoFormat(t *testing.T) {
 	// and we can download the snapshot
 	require.NoError(t, repo.RotateKey(data.CanonicalSnapshotRole, true, nil))
 	require.NoError(t, repo.Publish())
-	err = repo.Update(false)
+	err = repo.updateTUF(false)
 	require.NoError(t, err)
 }
 
@@ -333,7 +333,7 @@ func TestDownloading0Dot1RepoFormat(t *testing.T) {
 	require.NoError(t, err, "error creating repo: %s", err)
 	repo := r.(*repository)
 
-	err = repo.Update(true)
+	err = repo.updateTUF(true)
 	require.NoError(t, err, "error updating repo: %s", err)
 }
 
@@ -359,6 +359,6 @@ func TestDownloading0Dot3RepoFormat(t *testing.T) {
 	require.NoError(t, err, "error creating repo: %s", err)
 	repo := r.(*repository)
 
-	err = repo.Update(true)
+	err = repo.updateTUF(true)
 	require.NoError(t, err, "error updating repo: %s", err)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -7,10 +7,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
-	"regexp"
 	"time"
 
 	canonicaljson "github.com/docker/go/canonical/json"
@@ -127,20 +125,62 @@ func (r *repository) GetGUN() data.GUN {
 	return r.gun
 }
 
-// Target represents a simplified version of the data TUF operates on, so external
-// applications don't have to depend on TUF data types.
-type Target struct {
-	Name   string                    // the name of the target
-	Hashes data.Hashes               // the hash of the target
-	Length int64                     // the size in bytes of the target
-	Custom *canonicaljson.RawMessage // the custom data provided to describe the file at TARGETPATH
+func (r *repository) updateTUF(forWrite bool) error {
+	repo, invalid, err := LoadTUFRepo(TUFLoadOptions{
+		GUN:                    r.gun,
+		TrustPinning:           r.trustPinning,
+		CryptoService:          r.cryptoService,
+		Cache:                  r.cache,
+		RemoteStore:            r.remoteStore,
+		AlwaysCheckInitialized: forWrite,
+	})
+	if err != nil {
+		return err
+	}
+	r.tufRepo = repo
+	r.invalid = invalid
+	return nil
 }
 
-// TargetWithRole represents a Target that exists in a particular role - this is
-// produced by ListTargets and GetTargetByName
-type TargetWithRole struct {
-	Target
-	Role data.RoleName
+// ListTargets calls update first before listing targets
+func (r *repository) ListTargets(roles ...data.RoleName) ([]*TargetWithRole, error) {
+	if err := r.updateTUF(false); err != nil {
+		return nil, err
+	}
+	return NewReadOnly(r.tufRepo).ListTargets(roles...)
+}
+
+// GetTargetByName calls update first before getting target by name
+func (r *repository) GetTargetByName(name string, roles ...data.RoleName) (*TargetWithRole, error) {
+	if err := r.updateTUF(false); err != nil {
+		return nil, err
+	}
+	return NewReadOnly(r.tufRepo).GetTargetByName(name, roles...)
+}
+
+// GetAllTargetMetadataByName calls update first before getting targets by name
+func (r *repository) GetAllTargetMetadataByName(name string) ([]TargetSignedStruct, error) {
+	if err := r.updateTUF(false); err != nil {
+		return nil, err
+	}
+	return NewReadOnly(r.tufRepo).GetAllTargetMetadataByName(name)
+
+}
+
+// ListRoles calls update first before getting roles
+func (r *repository) ListRoles() ([]RoleWithSignatures, error) {
+	if err := r.updateTUF(false); err != nil {
+		return nil, err
+	}
+	return NewReadOnly(r.tufRepo).ListRoles()
+}
+
+// GetDelegationRoles calls update first before getting all delegation roles
+func (r *repository) GetDelegationRoles() ([]data.Role, error) {
+	if err := r.updateTUF(false); err != nil {
+		return nil, err
+	}
+	return NewReadOnly(r.tufRepo).GetDelegationRoles()
 }
 
 // NewTarget is a helper method that returns a Target
@@ -489,167 +529,6 @@ func (r *repository) RemoveTarget(targetName string, roles ...data.RoleName) err
 	return addChange(r.changelist, template, roles...)
 }
 
-// ListTargets lists all targets for the current repository. The list of
-// roles should be passed in order from highest to lowest priority.
-//
-// IMPORTANT: if you pass a set of roles such as [ "targets/a", "targets/x"
-// "targets/a/b" ], even though "targets/a/b" is part of the "targets/a" subtree
-// its entries will be strictly shadowed by those in other parts of the "targets/a"
-// subtree and also the "targets/x" subtree, as we will defer parsing it until
-// we explicitly reach it in our iteration of the provided list of roles.
-func (r *repository) ListTargets(roles ...data.RoleName) ([]*TargetWithRole, error) {
-	if err := r.Update(false); err != nil {
-		return nil, err
-	}
-
-	if len(roles) == 0 {
-		roles = []data.RoleName{data.CanonicalTargetsRole}
-	}
-	targets := make(map[string]*TargetWithRole)
-	for _, role := range roles {
-		// Define an array of roles to skip for this walk (see IMPORTANT comment above)
-		skipRoles := utils.RoleNameSliceRemove(roles, role)
-
-		// Define a visitor function to populate the targets map in priority order
-		listVisitorFunc := func(tgt *data.SignedTargets, validRole data.DelegationRole) interface{} {
-			// We found targets so we should try to add them to our targets map
-			for targetName, targetMeta := range tgt.Signed.Targets {
-				// Follow the priority by not overriding previously set targets
-				// and check that this path is valid with this role
-				if _, ok := targets[targetName]; ok || !validRole.CheckPaths(targetName) {
-					continue
-				}
-				targets[targetName] = &TargetWithRole{
-					Target: Target{
-						Name:   targetName,
-						Hashes: targetMeta.Hashes,
-						Length: targetMeta.Length,
-						Custom: targetMeta.Custom,
-					},
-					Role: validRole.Name,
-				}
-			}
-			return nil
-		}
-
-		r.tufRepo.WalkTargets("", role, listVisitorFunc, skipRoles...)
-	}
-
-	var targetList []*TargetWithRole
-	for _, v := range targets {
-		targetList = append(targetList, v)
-	}
-
-	return targetList, nil
-}
-
-// GetTargetByName returns a target by the given name. If no roles are passed
-// it uses the targets role and does a search of the entire delegation
-// graph, finding the first entry in a breadth first search of the delegations.
-// If roles are passed, they should be passed in descending priority and
-// the target entry found in the subtree of the highest priority role
-// will be returned.
-// See the IMPORTANT section on ListTargets above. Those roles also apply here.
-func (r *repository) GetTargetByName(name string, roles ...data.RoleName) (*TargetWithRole, error) {
-	if err := r.Update(false); err != nil {
-		return nil, err
-	}
-
-	if len(roles) == 0 {
-		roles = append(roles, data.CanonicalTargetsRole)
-	}
-	var resultMeta data.FileMeta
-	var resultRoleName data.RoleName
-	var foundTarget bool
-	for _, role := range roles {
-		// Define an array of roles to skip for this walk (see IMPORTANT comment above)
-		skipRoles := utils.RoleNameSliceRemove(roles, role)
-
-		// Define a visitor function to find the specified target
-		getTargetVisitorFunc := func(tgt *data.SignedTargets, validRole data.DelegationRole) interface{} {
-			if tgt == nil {
-				return nil
-			}
-			// We found the target and validated path compatibility in our walk,
-			// so we should stop our walk and set the resultMeta and resultRoleName variables
-			if resultMeta, foundTarget = tgt.Signed.Targets[name]; foundTarget {
-				resultRoleName = validRole.Name
-				return tuf.StopWalk{}
-			}
-			return nil
-		}
-		// Check that we didn't error, and that we assigned to our target
-		if err := r.tufRepo.WalkTargets(name, role, getTargetVisitorFunc, skipRoles...); err == nil && foundTarget {
-			return &TargetWithRole{Target: Target{Name: name, Hashes: resultMeta.Hashes, Length: resultMeta.Length, Custom: resultMeta.Custom}, Role: resultRoleName}, nil
-		}
-	}
-	return nil, ErrNoSuchTarget(name)
-
-}
-
-// TargetSignedStruct is a struct that contains a Target, the role it was found in, and the list of signatures for that role
-type TargetSignedStruct struct {
-	Role       data.DelegationRole
-	Target     Target
-	Signatures []data.Signature
-}
-
-//ErrNoSuchTarget is returned when no valid trust data is found.
-type ErrNoSuchTarget string
-
-func (f ErrNoSuchTarget) Error() string {
-	return fmt.Sprintf("No valid trust data for %s", string(f))
-}
-
-// GetAllTargetMetadataByName searches the entire delegation role tree to find the specified target by name for all
-// roles, and returns a list of TargetSignedStructs for each time it finds the specified target.
-// If given an empty string for a target name, it will return back all targets signed into the repository in every role
-func (r *repository) GetAllTargetMetadataByName(name string) ([]TargetSignedStruct, error) {
-	if err := r.Update(false); err != nil {
-		return nil, err
-	}
-
-	var targetInfoList []TargetSignedStruct
-
-	// Define a visitor function to find the specified target
-	getAllTargetInfoByNameVisitorFunc := func(tgt *data.SignedTargets, validRole data.DelegationRole) interface{} {
-		if tgt == nil {
-			return nil
-		}
-		// We found a target and validated path compatibility in our walk,
-		// so add it to our list if we have a match
-		// if we have an empty name, add all targets, else check if we have it
-		var targetMetaToAdd data.Files
-		if name == "" {
-			targetMetaToAdd = tgt.Signed.Targets
-		} else {
-			if meta, ok := tgt.Signed.Targets[name]; ok {
-				targetMetaToAdd = data.Files{name: meta}
-			}
-		}
-
-		for targetName, resultMeta := range targetMetaToAdd {
-			targetInfo := TargetSignedStruct{
-				Role:       validRole,
-				Target:     Target{Name: targetName, Hashes: resultMeta.Hashes, Length: resultMeta.Length, Custom: resultMeta.Custom},
-				Signatures: tgt.Signatures,
-			}
-			targetInfoList = append(targetInfoList, targetInfo)
-		}
-		// continue walking to all child roles
-		return nil
-	}
-
-	// Check that we didn't error, and that we found the target at least once
-	if err := r.tufRepo.WalkTargets(name, "", getAllTargetInfoByNameVisitorFunc); err != nil {
-		return nil, err
-	}
-	if len(targetInfoList) == 0 {
-		return nil, ErrNoSuchTarget(name)
-	}
-	return targetInfoList, nil
-}
-
 // GetChangelist returns the list of the repository's unpublished changes
 func (r *repository) GetChangelist() (changelist.Changelist, error) {
 	return r.changelist, nil
@@ -665,51 +544,6 @@ func (r *repository) getRemoteStore() store.RemoteStore {
 	r.remoteStore = &store.OfflineStore{}
 
 	return r.remoteStore
-}
-
-// RoleWithSignatures is a Role with its associated signatures
-type RoleWithSignatures struct {
-	Signatures []data.Signature
-	data.Role
-}
-
-// ListRoles returns a list of RoleWithSignatures objects for this repo
-// This represents the latest metadata for each role in this repo
-func (r *repository) ListRoles() ([]RoleWithSignatures, error) {
-	// Update to latest repo state
-	if err := r.Update(false); err != nil {
-		return nil, err
-	}
-
-	// Get all role info from our updated keysDB, can be empty
-	roles := r.tufRepo.GetAllLoadedRoles()
-
-	var roleWithSigs []RoleWithSignatures
-
-	// Populate RoleWithSignatures with Role from keysDB and signatures from TUF metadata
-	for _, role := range roles {
-		roleWithSig := RoleWithSignatures{Role: *role, Signatures: nil}
-		switch role.Name {
-		case data.CanonicalRootRole:
-			roleWithSig.Signatures = r.tufRepo.Root.Signatures
-		case data.CanonicalTargetsRole:
-			roleWithSig.Signatures = r.tufRepo.Targets[data.CanonicalTargetsRole].Signatures
-		case data.CanonicalSnapshotRole:
-			roleWithSig.Signatures = r.tufRepo.Snapshot.Signatures
-		case data.CanonicalTimestampRole:
-			roleWithSig.Signatures = r.tufRepo.Timestamp.Signatures
-		default:
-			if !data.IsDelegation(role.Name) {
-				continue
-			}
-			if _, ok := r.tufRepo.Targets[role.Name]; ok {
-				// We'll only find a signature if we've published any targets with this delegation
-				roleWithSig.Signatures = r.tufRepo.Targets[role.Name].Signatures
-			}
-		}
-		roleWithSigs = append(roleWithSigs, roleWithSig)
-	}
-	return roleWithSigs, nil
 }
 
 // Publish pushes the local changes in signed material to the remote notary-server
@@ -732,7 +566,7 @@ func (r *repository) Publish() error {
 func (r *repository) publish(cl changelist.Changelist) error {
 	var initialPublish bool
 	// update first before publishing
-	if err := r.Update(true); err != nil {
+	if err := r.updateTUF(true); err != nil {
 		// If the remote is not aware of the repo, then this is being published
 		// for the first time.  Try to initialize the repository before publishing.
 		if _, ok := err.(ErrRepositoryNotExist); ok {
@@ -859,7 +693,14 @@ func (r *repository) oldKeysForLegacyClientSupport(legacyVersions int, initialPu
 	}
 	oldKeys := make(map[string]data.PublicKey)
 
-	c, err := r.bootstrapClient(true)
+	c, err := bootstrapClient(TUFLoadOptions{
+		GUN:                    r.gun,
+		TrustPinning:           r.trustPinning,
+		CryptoService:          r.cryptoService,
+		Cache:                  r.cache,
+		RemoteStore:            r.remoteStore,
+		AlwaysCheckInitialized: true,
+	})
 	// require a server connection to fetch old roots
 	if err != nil {
 		return nil, err
@@ -997,135 +838,6 @@ func (r *repository) saveMetadata(ignoreSnapshot bool) error {
 	}
 
 	return r.cache.Set(data.CanonicalSnapshotRole.String(), snapshotJSON)
-}
-
-// returns a properly constructed ErrRepositoryNotExist error based on this
-// repo's information
-func (r *repository) errRepositoryNotExist() error {
-	host := r.baseURL
-	parsed, err := url.Parse(r.baseURL)
-	if err == nil {
-		host = parsed.Host // try to exclude the scheme and any paths
-	}
-	return ErrRepositoryNotExist{remote: host, gun: r.gun}
-}
-
-// Update bootstraps a trust anchor (root.json) before updating all the
-// metadata from the repo.
-func (r *repository) Update(forWrite bool) error {
-	c, err := r.bootstrapClient(forWrite)
-	if err != nil {
-		if _, ok := err.(store.ErrMetaNotFound); ok {
-			return r.errRepositoryNotExist()
-		}
-		return err
-	}
-	repo, invalid, err := c.Update()
-	if err != nil {
-		// notFound.Resource may include a version or checksum so when the role is root,
-		// it will be root, <version>.root or root.<checksum>.
-		notFound, ok := err.(store.ErrMetaNotFound)
-		isRoot, _ := regexp.MatchString(`\.?`+data.CanonicalRootRole.String()+`\.?`, notFound.Resource)
-		if ok && isRoot {
-			return r.errRepositoryNotExist()
-		}
-		return err
-	}
-	// we can be assured if we are at this stage that the repo we built is good
-	// no need to test the following function call for an error as it will always be fine should the repo be good- it is!
-	r.tufRepo = repo
-	r.invalid = invalid
-	warnRolesNearExpiry(repo)
-	return nil
-}
-
-// bootstrapClient attempts to bootstrap a root.json to be used as the trust
-// anchor for a repository. The checkInitialized argument indicates whether
-// we should always attempt to contact the server to determine if the repository
-// is initialized or not. If set to true, we will always attempt to download
-// and return an error if the remote repository errors.
-//
-// Populates a tuf.RepoBuilder with this root metadata. If the root metadata
-// downloaded is a newer version than what is on disk, then intermediate
-// versions will be downloaded and verified in order to rotate trusted keys
-// properly. Newer root metadata must always be signed with the previous
-// threshold and keys.
-//
-// Fails if the remote server is reachable and does not know the repo
-// (i.e. before the first r.Publish()), in which case the error is
-// store.ErrMetaNotFound, or if the root metadata (from whichever source is used)
-// is not trusted.
-//
-// Returns a TUFClient for the remote server, which may not be actually
-// operational (if the URL is invalid but a root.json is cached).
-func (r *repository) bootstrapClient(checkInitialized bool) (*tufClient, error) {
-	minVersion := 1
-	// the old root on disk should not be validated against any trust pinning configuration
-	// because if we have an old root, it itself is the thing that pins trust
-	oldBuilder := tuf.NewRepoBuilder(r.gun, r.GetCryptoService(), trustpinning.TrustPinConfig{})
-
-	// by default, we want to use the trust pinning configuration on any new root that we download
-	newBuilder := tuf.NewRepoBuilder(r.gun, r.GetCryptoService(), r.trustPinning)
-
-	// Try to read root from cache first. We will trust this root until we detect a problem
-	// during update which will cause us to download a new root and perform a rotation.
-	// If we have an old root, and it's valid, then we overwrite the newBuilder to be one
-	// preloaded with the old root or one which uses the old root for trust bootstrapping.
-	if rootJSON, err := r.cache.GetSized(data.CanonicalRootRole.String(), store.NoSizeLimit); err == nil {
-		// if we can't load the cached root, fail hard because that is how we pin trust
-		if err := oldBuilder.Load(data.CanonicalRootRole, rootJSON, minVersion, true); err != nil {
-			return nil, err
-		}
-
-		// again, the root on disk is the source of trust pinning, so use an empty trust
-		// pinning configuration
-		newBuilder = tuf.NewRepoBuilder(r.gun, r.GetCryptoService(), trustpinning.TrustPinConfig{})
-
-		if err := newBuilder.Load(data.CanonicalRootRole, rootJSON, minVersion, false); err != nil {
-			// Ok, the old root is expired - we want to download a new one.  But we want to use the
-			// old root to verify the new root, so bootstrap a new builder with the old builder
-			// but use the trustpinning to validate the new root
-			minVersion = oldBuilder.GetLoadedVersion(data.CanonicalRootRole)
-			newBuilder = oldBuilder.BootstrapNewBuilderWithNewTrustpin(r.trustPinning)
-		}
-	}
-
-	remote := r.getRemoteStore()
-
-	if !newBuilder.IsLoaded(data.CanonicalRootRole) || checkInitialized {
-		// remoteErr was nil and we were not able to load a root from cache or
-		// are specifically checking for initialization of the repo.
-
-		// if remote store successfully set up, try and get root from remote
-		// We don't have any local data to determine the size of root, so try the maximum (though it is restricted at 100MB)
-		tmpJSON, err := remote.GetSized(data.CanonicalRootRole.String(), store.NoSizeLimit)
-		if err != nil {
-			// we didn't have a root in cache and were unable to load one from
-			// the server. Nothing we can do but error.
-			return nil, err
-		}
-
-		if !newBuilder.IsLoaded(data.CanonicalRootRole) {
-			// we always want to use the downloaded root if we couldn't load from cache
-			if err := newBuilder.Load(data.CanonicalRootRole, tmpJSON, minVersion, false); err != nil {
-				return nil, err
-			}
-
-			err = r.cache.Set(data.CanonicalRootRole.String(), tmpJSON)
-			if err != nil {
-				// if we can't write cache we should still continue, just log error
-				logrus.Errorf("could not save root to cache: %s", err.Error())
-			}
-		}
-	}
-
-	// We can only get here if remoteErr != nil (hence we don't download any new root),
-	// and there was no root on disk
-	if !newBuilder.IsLoaded(data.CanonicalRootRole) {
-		return nil, ErrRepoNotInitialized{}
-	}
-
-	return newTufClient(oldBuilder, newBuilder, remote, r.cache), nil
 }
 
 // RotateKey removes all existing keys associated with the role. If no keys are

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2678,7 +2678,7 @@ func TestRotateKeyInvalidRole(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, repo.AddDelegation("targets/releases", []data.PublicKey{pubKey}, []string{""}))
 	require.NoError(t, repo.Publish())
-	require.NoError(t, repo.Update(false))
+	require.NoError(t, repo.updateTUF(false))
 
 	// rotating a root key to the server fails
 	require.Error(t, repo.RotateKey(data.CanonicalRootRole, true, nil),
@@ -2805,7 +2805,7 @@ func requireRotationSuccessful(t *testing.T, repo1 *repository, keysToRotate map
 
 	// Download data from remote and check that keys have changed
 	for _, repo := range repos {
-		err := repo.Update(true)
+		err := repo.updateTUF(true)
 		require.NoError(t, err)
 
 		for roleName, isRemoteKey := range keysToRotate {
@@ -2983,7 +2983,7 @@ func TestRotateRootKey(t *testing.T) {
 	// Initialize an user, using the original root cert and key.
 	userRepo, _, baseDir := newRepoToTestRepo(t, authorRepo, "")
 	defer os.RemoveAll(baseDir)
-	err = userRepo.Update(false)
+	err = userRepo.updateTUF(false)
 	require.NoError(t, err)
 
 	// Rotate root certificate and key.
@@ -2992,7 +2992,7 @@ func TestRotateRootKey(t *testing.T) {
 	require.NoError(t, err)
 	logRepoTrustRoot(t, "post-rotate", authorRepo)
 
-	require.NoError(t, authorRepo.Update(false))
+	require.NoError(t, authorRepo.updateTUF(false))
 	newRootRole, err := authorRepo.tufRepo.GetBaseRole(data.CanonicalRootRole)
 	require.NoError(t, err)
 	require.False(t, newRootRole.Equals(oldRootRole))
@@ -3031,7 +3031,7 @@ func TestRotateRootKey(t *testing.T) {
 
 	// Verify that the user initialized with the original certificate eventually
 	// rotates to the new certificate.
-	err = userRepo.Update(false)
+	err = userRepo.updateTUF(false)
 	require.NoError(t, err)
 	logRepoTrustRoot(t, "user refresh 1", userRepo)
 	require.Equal(t, newRootCertID, rootRoleCertID(t, userRepo))
@@ -3055,7 +3055,7 @@ func TestRotateRootMultiple(t *testing.T) {
 	// Initialize a user, using the original root cert and key.
 	userRepo, _, baseDir := newRepoToTestRepo(t, authorRepo, "")
 	defer os.RemoveAll(baseDir)
-	err = userRepo.Update(false)
+	err = userRepo.updateTUF(false)
 	require.NoError(t, err)
 
 	// Rotate root certificate and key.
@@ -3069,7 +3069,7 @@ func TestRotateRootMultiple(t *testing.T) {
 	require.NoError(t, err)
 	logRepoTrustRoot(t, "post-rotate-again", authorRepo)
 
-	require.NoError(t, authorRepo.Update(false))
+	require.NoError(t, authorRepo.updateTUF(false))
 	newRootRole, err := authorRepo.tufRepo.GetBaseRole(data.CanonicalRootRole)
 	require.NoError(t, err)
 	require.False(t, newRootRole.Equals(oldRootRole))
@@ -3093,7 +3093,7 @@ func TestRotateRootMultiple(t *testing.T) {
 	logRepoTrustRoot(t, "post-publish", authorRepo)
 
 	// Verify the user can use the rotated repo, and see the added target.
-	err = userRepo.Update(false)
+	err = userRepo.updateTUF(false)
 	require.NoError(t, err)
 	_, err = userRepo.GetTargetByName("current")
 	require.NoError(t, err)
@@ -3110,7 +3110,7 @@ func TestRotateRootMultiple(t *testing.T) {
 
 	// Verify that the user initialized with the original certificate eventually
 	// rotates to the new certificate.
-	err = userRepo.Update(false)
+	err = userRepo.updateTUF(false)
 	require.NoError(t, err)
 	logRepoTrustRoot(t, "user refresh 1", userRepo)
 	require.Equal(t, newRootCertID, rootRoleCertID(t, userRepo))
@@ -3134,7 +3134,7 @@ func TestRotateRootKeyProvided(t *testing.T) {
 	// Initialize an user, using the original root cert and key.
 	userRepo, _, baseDir := newRepoToTestRepo(t, authorRepo, "")
 	defer os.RemoveAll(baseDir)
-	err = userRepo.Update(false)
+	err = userRepo.updateTUF(false)
 	require.NoError(t, err)
 
 	// Key loaded from file (just generating it here)
@@ -3153,7 +3153,7 @@ func TestRotateRootKeyProvided(t *testing.T) {
 	require.NoError(t, err)
 	logRepoTrustRoot(t, "post-rotate", authorRepo)
 
-	require.NoError(t, authorRepo.Update(false))
+	require.NoError(t, authorRepo.updateTUF(false))
 	newRootRole, err := authorRepo.tufRepo.GetBaseRole(data.CanonicalRootRole)
 	require.False(t, newRootRole.Equals(oldRootRole))
 	require.NoError(t, err)
@@ -3193,7 +3193,7 @@ func TestRotateRootKeyProvided(t *testing.T) {
 
 	// Verify that the user initialized with the original certificate eventually
 	// rotates to the new certificate.
-	err = userRepo.Update(false)
+	err = userRepo.updateTUF(false)
 	require.NoError(t, err)
 	logRepoTrustRoot(t, "user refresh 1", userRepo)
 	require.Equal(t, newRootCertID, rootRoleCertID(t, userRepo))
@@ -3217,7 +3217,7 @@ func TestRotateRootKeyLegacySupport(t *testing.T) {
 	// Initialize a user, using the original root cert and key.
 	userRepo, _, baseDir := newRepoToTestRepo(t, authorRepo, "")
 	defer os.RemoveAll(baseDir)
-	err = userRepo.Update(false)
+	err = userRepo.updateTUF(false)
 	require.NoError(t, err)
 
 	// Rotate root certificate and key.
@@ -3232,7 +3232,7 @@ func TestRotateRootKeyLegacySupport(t *testing.T) {
 	require.NoError(t, err)
 	logRepoTrustRoot(t, "post-rotate-again", authorRepo)
 
-	require.NoError(t, authorRepo.Update(false))
+	require.NoError(t, authorRepo.updateTUF(false))
 	newRootRole, err := authorRepo.tufRepo.GetBaseRole(data.CanonicalRootRole)
 	require.NoError(t, err)
 	require.False(t, newRootRole.Equals(oldRootRole))
@@ -3256,7 +3256,7 @@ func TestRotateRootKeyLegacySupport(t *testing.T) {
 	logRepoTrustRoot(t, "post-publish", authorRepo)
 
 	// Verify the user can use the rotated repo, and see the added target.
-	err = userRepo.Update(false)
+	err = userRepo.updateTUF(false)
 	require.NoError(t, err)
 	_, err = userRepo.GetTargetByName("current")
 	require.NoError(t, err)
@@ -3277,7 +3277,7 @@ func TestRotateRootKeyLegacySupport(t *testing.T) {
 
 	// Verify that the user initialized with the original certificate eventually
 	// rotates to the new certificate.
-	err = userRepo.Update(false)
+	err = userRepo.updateTUF(false)
 	require.NoError(t, err)
 	logRepoTrustRoot(t, "user refresh 1", userRepo)
 	require.Equal(t, newRootCertID, rootRoleCertID(t, userRepo))
@@ -3598,37 +3598,6 @@ func TestRemoveDelegationErrorWritingChanges(t *testing.T) {
 	testErrorWritingChangefiles(t, func(repo *repository) error {
 		return repo.RemoveDelegationKeysAndPaths("targets/a", []string{""}, []string{})
 	})
-}
-
-// TestBootstrapClientBadURL checks that bootstrapClient correctly
-// returns an error when the URL is valid but does not point to
-// a TUF server
-func TestBootstrapClientBadURL(t *testing.T) {
-	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	require.NoError(t, err, "failed to create a temporary directory: %s", err)
-	r, err := NewFileCachedRepository(
-		tempBaseDir,
-		"testGun",
-		"http://localhost:9998",
-		http.DefaultTransport,
-		passphraseRetriever,
-		trustpinning.TrustPinConfig{},
-	)
-	require.NoError(t, err, "error creating repo: %s", err)
-	repo := r.(*repository)
-
-	c, err := repo.bootstrapClient(false)
-	require.Nil(t, c)
-	require.Error(t, err)
-
-	c, err2 := repo.bootstrapClient(true)
-	require.Nil(t, c)
-	require.Error(t, err2)
-
-	// same error should be returned because we don't have local data
-	// and are requesting remote root regardless of checkInitialized
-	// value
-	require.EqualError(t, err, err2.Error())
 }
 
 // TestClientInvalidURL checks that instantiating a new repository

--- a/client/interface.go
+++ b/client/interface.go
@@ -6,42 +6,145 @@ import (
 	"github.com/theupdateframework/notary/tuf/signed"
 )
 
-// Repository represents the set of options that must be supported over a TUF repo.
-type Repository interface {
-	// General management operations
-	Initialize(rootKeyIDs []string, serverManagedRoles ...data.RoleName) error
-	InitializeWithCertificate(rootKeyIDs []string, rootCerts []data.PublicKey, serverManagedRoles ...data.RoleName) error
-	Publish() error
-
-	// Target Operations
-	AddTarget(target *Target, roles ...data.RoleName) error
-	RemoveTarget(targetName string, roles ...data.RoleName) error
+// ReadOnly represents the set of options that must be supported over a TUF repo for
+// reading
+type ReadOnly interface {
+	// ListTargets lists all targets for the current repository. The list of
+	// roles should be passed in order from highest to lowest priority.
+	//
+	// IMPORTANT: if you pass a set of roles such as [ "targets/a", "targets/x"
+	// "targets/a/b" ], even though "targets/a/b" is part of the "targets/a" subtree
+	// its entries will be strictly shadowed by those in other parts of the "targets/a"
+	// subtree and also the "targets/x" subtree, as we will defer parsing it until
+	// we explicitly reach it in our iteration of the provided list of roles.
 	ListTargets(roles ...data.RoleName) ([]*TargetWithRole, error)
+
+	// GetTargetByName returns a target by the given name. If no roles are passed
+	// it uses the targets role and does a search of the entire delegation
+	// graph, finding the first entry in a breadth first search of the delegations.
+	// If roles are passed, they should be passed in descending priority and
+	// the target entry found in the subtree of the highest priority role
+	// will be returned.
+	// See the IMPORTANT section on ListTargets above. Those roles also apply here.
 	GetTargetByName(name string, roles ...data.RoleName) (*TargetWithRole, error)
+
+	// GetAllTargetMetadataByName searches the entire delegation role tree to find
+	// the specified target by name for all roles, and returns a list of
+	// TargetSignedStructs for each time it finds the specified target.
+	// If given an empty string for a target name, it will return back all targets
+	// signed into the repository in every role
 	GetAllTargetMetadataByName(name string) ([]TargetSignedStruct, error)
 
-	// Changelist operations
+	// ListRoles returns a list of RoleWithSignatures objects for this repo
+	// This represents the latest metadata for each role in this repo
+	ListRoles() ([]RoleWithSignatures, error)
+
+	// GetDelegationRoles returns the keys and roles of the repository's delegations
+	// Also converts key IDs to canonical key IDs to keep consistent with signing prompts
+	GetDelegationRoles() ([]data.Role, error)
+}
+
+// Repository represents the set of options that must be supported over a TUF repo
+// for both reading and writing.
+type Repository interface {
+	ReadOnly
+
+	// ------------------- Publishing operations -------------------
+
+	// GetGUN returns the GUN assocated with the repository
+	GetGUN() data.GUN
+
+	// SetLegacyVersion sets the number of versions back to fetch roots to sign with
+	SetLegacyVersions(int)
+
+	// ----- General management operations -----
+
+	// Initialize creates a new repository by using rootKey as the root Key for the
+	// TUF repository. The remote store/server must be reachable (and is asked to
+	// generate a timestamp key and possibly other serverManagedRoles), but the
+	// created repository result is only stored on local cache, not published to
+	// the remote store. To do that, use r.Publish() eventually.
+	Initialize(rootKeyIDs []string, serverManagedRoles ...data.RoleName) error
+
+	// InitializeWithCertificate initializes the repository with root keys and their
+	// corresponding certificates
+	InitializeWithCertificate(rootKeyIDs []string, rootCerts []data.PublicKey, serverManagedRoles ...data.RoleName) error
+
+	// Publish pushes the local changes in signed material to the remote notary-server
+	// Conceptually it performs an operation similar to a `git rebase`
+	Publish() error
+
+	// ----- Target Operations -----
+
+	// AddTarget creates new changelist entries to add a target to the given roles
+	// in the repository when the changelist gets applied at publish time.
+	// If roles are unspecified, the default role is "targets"
+	AddTarget(target *Target, roles ...data.RoleName) error
+
+	// RemoveTarget creates new changelist entries to remove a target from the given
+	// roles in the repository when the changelist gets applied at publish time.
+	// If roles are unspecified, the default role is "target".
+	RemoveTarget(targetName string, roles ...data.RoleName) error
+
+	// ----- Changelist operations -----
+
+	// GetChangelist returns the list of the repository's unpublished changes
 	GetChangelist() (changelist.Changelist, error)
 
-	// Role operations
-	ListRoles() ([]RoleWithSignatures, error)
-	GetDelegationRoles() ([]data.Role, error)
+	// ----- Role operations -----
+
+	// AddDelegation creates changelist entries to add provided delegation public keys and paths.
+	// This method composes AddDelegationRoleAndKeys and AddDelegationPaths (each creates one changelist if called).
 	AddDelegation(name data.RoleName, delegationKeys []data.PublicKey, paths []string) error
+
+	// AddDelegationRoleAndKeys creates a changelist entry to add provided delegation public keys.
+	// This method is the simplest way to create a new delegation, because the delegation must have at least
+	// one key upon creation to be valid since we will reject the changelist while validating the threshold.
 	AddDelegationRoleAndKeys(name data.RoleName, delegationKeys []data.PublicKey) error
+
+	// AddDelegationPaths creates a changelist entry to add provided paths to an existing delegation.
+	// This method cannot create a new delegation itself because the role must meet the key threshold upon
+	// creation.
 	AddDelegationPaths(name data.RoleName, paths []string) error
+
+	// RemoveDelegationKeysAndPaths creates changelist entries to remove provided delegation key IDs and
+	// paths. This method composes RemoveDelegationPaths and RemoveDelegationKeys (each creates one
+	// changelist entry if called).
 	RemoveDelegationKeysAndPaths(name data.RoleName, keyIDs, paths []string) error
+
+	// RemoveDelegationRole creates a changelist to remove all paths and keys from a role, and delete the
+	// role in its entirety.
 	RemoveDelegationRole(name data.RoleName) error
+
+	// RemoveDelegationPaths creates a changelist entry to remove provided paths from an existing delegation.
 	RemoveDelegationPaths(name data.RoleName, paths []string) error
+
+	// RemoveDelegationKeys creates a changelist entry to remove provided keys from an existing delegation.
+	// When this changelist is applied, if the specified keys are the only keys left in the role,
+	// the role itself will be deleted in its entirety.
+	// It can also delete a key from all delegations under a parent using a name
+	// with a wildcard at the end.
 	RemoveDelegationKeys(name data.RoleName, keyIDs []string) error
+
+	// ClearDelegationPaths creates a changelist entry to remove all paths from an existing delegation.
 	ClearDelegationPaths(name data.RoleName) error
 
-	// Witness and other re-signing operations
+	// ----- Witness and other re-signing operations -----
+
+	// Witness creates change objects to witness (i.e. re-sign) the given
+	// roles on the next publish. One change is created per role
 	Witness(roles ...data.RoleName) ([]data.RoleName, error)
 
-	// Key Operations
+	// ----- Key Operations -----
+
+	// RotateKey removes all existing keys associated with the role. If no keys are
+	// specified in keyList, then this creates and adds one new key or delegates
+	// managing the key to the server. If key(s) are specified by keyList, then they are
+	// used for signing the role.
+	// These changes are staged in a changelist until publish is called.
 	RotateKey(role data.RoleName, serverManagesKey bool, keyList []string) error
 
+	// GetCryptoService is the getter for the repository's CryptoService, which is used
+	// to sign all updates.
 	GetCryptoService() signed.CryptoService
-	SetLegacyVersions(int)
-	GetGUN() data.GUN
 }

--- a/client/reader.go
+++ b/client/reader.go
@@ -1,0 +1,257 @@
+package client
+
+import (
+	"fmt"
+
+	canonicaljson "github.com/docker/go/canonical/json"
+	store "github.com/theupdateframework/notary/storage"
+	"github.com/theupdateframework/notary/tuf"
+	"github.com/theupdateframework/notary/tuf/data"
+	"github.com/theupdateframework/notary/tuf/utils"
+)
+
+// Target represents a simplified version of the data TUF operates on, so external
+// applications don't have to depend on TUF data types.
+type Target struct {
+	Name   string                    // the name of the target
+	Hashes data.Hashes               // the hash of the target
+	Length int64                     // the size in bytes of the target
+	Custom *canonicaljson.RawMessage // the custom data provided to describe the file at TARGETPATH
+}
+
+// TargetWithRole represents a Target that exists in a particular role - this is
+// produced by ListTargets and GetTargetByName
+type TargetWithRole struct {
+	Target
+	Role data.RoleName
+}
+
+// TargetSignedStruct is a struct that contains a Target, the role it was found in, and the list of signatures for that role
+type TargetSignedStruct struct {
+	Role       data.DelegationRole
+	Target     Target
+	Signatures []data.Signature
+}
+
+//ErrNoSuchTarget is returned when no valid trust data is found.
+type ErrNoSuchTarget string
+
+func (f ErrNoSuchTarget) Error() string {
+	return fmt.Sprintf("No valid trust data for %s", string(f))
+}
+
+// RoleWithSignatures is a Role with its associated signatures
+type RoleWithSignatures struct {
+	Signatures []data.Signature
+	data.Role
+}
+
+// NewReadOnly is the base method that returns a new notary repository for reading.
+// It expects an initialized cache. In case of a nil remote store, a default
+// offline store is used.
+func NewReadOnly(repo *tuf.Repo) ReadOnly {
+	return &reader{tufRepo: repo}
+}
+
+type reader struct {
+	tufRepo *tuf.Repo
+}
+
+// ListTargets lists all targets for the current repository. The list of
+// roles should be passed in order from highest to lowest priority.
+//
+// IMPORTANT: if you pass a set of roles such as [ "targets/a", "targets/x"
+// "targets/a/b" ], even though "targets/a/b" is part of the "targets/a" subtree
+// its entries will be strictly shadowed by those in other parts of the "targets/a"
+// subtree and also the "targets/x" subtree, as we will defer parsing it until
+// we explicitly reach it in our iteration of the provided list of roles.
+func (r *reader) ListTargets(roles ...data.RoleName) ([]*TargetWithRole, error) {
+	if len(roles) == 0 {
+		roles = []data.RoleName{data.CanonicalTargetsRole}
+	}
+	targets := make(map[string]*TargetWithRole)
+	for _, role := range roles {
+		// Define an array of roles to skip for this walk (see IMPORTANT comment above)
+		skipRoles := utils.RoleNameSliceRemove(roles, role)
+
+		// Define a visitor function to populate the targets map in priority order
+		listVisitorFunc := func(tgt *data.SignedTargets, validRole data.DelegationRole) interface{} {
+			// We found targets so we should try to add them to our targets map
+			for targetName, targetMeta := range tgt.Signed.Targets {
+				// Follow the priority by not overriding previously set targets
+				// and check that this path is valid with this role
+				if _, ok := targets[targetName]; ok || !validRole.CheckPaths(targetName) {
+					continue
+				}
+				targets[targetName] = &TargetWithRole{
+					Target: Target{
+						Name:   targetName,
+						Hashes: targetMeta.Hashes,
+						Length: targetMeta.Length,
+						Custom: targetMeta.Custom,
+					},
+					Role: validRole.Name,
+				}
+			}
+			return nil
+		}
+
+		r.tufRepo.WalkTargets("", role, listVisitorFunc, skipRoles...)
+	}
+
+	var targetList []*TargetWithRole
+	for _, v := range targets {
+		targetList = append(targetList, v)
+	}
+
+	return targetList, nil
+}
+
+// GetTargetByName returns a target by the given name. If no roles are passed
+// it uses the targets role and does a search of the entire delegation
+// graph, finding the first entry in a breadth first search of the delegations.
+// If roles are passed, they should be passed in descending priority and
+// the target entry found in the subtree of the highest priority role
+// will be returned.
+// See the IMPORTANT section on ListTargets above. Those roles also apply here.
+func (r *reader) GetTargetByName(name string, roles ...data.RoleName) (*TargetWithRole, error) {
+	if len(roles) == 0 {
+		roles = append(roles, data.CanonicalTargetsRole)
+	}
+	var resultMeta data.FileMeta
+	var resultRoleName data.RoleName
+	var foundTarget bool
+	for _, role := range roles {
+		// Define an array of roles to skip for this walk (see IMPORTANT comment above)
+		skipRoles := utils.RoleNameSliceRemove(roles, role)
+
+		// Define a visitor function to find the specified target
+		getTargetVisitorFunc := func(tgt *data.SignedTargets, validRole data.DelegationRole) interface{} {
+			if tgt == nil {
+				return nil
+			}
+			// We found the target and validated path compatibility in our walk,
+			// so we should stop our walk and set the resultMeta and resultRoleName variables
+			if resultMeta, foundTarget = tgt.Signed.Targets[name]; foundTarget {
+				resultRoleName = validRole.Name
+				return tuf.StopWalk{}
+			}
+			return nil
+		}
+		// Check that we didn't error, and that we assigned to our target
+		if err := r.tufRepo.WalkTargets(name, role, getTargetVisitorFunc, skipRoles...); err == nil && foundTarget {
+			return &TargetWithRole{Target: Target{Name: name, Hashes: resultMeta.Hashes, Length: resultMeta.Length, Custom: resultMeta.Custom}, Role: resultRoleName}, nil
+		}
+	}
+	return nil, ErrNoSuchTarget(name)
+
+}
+
+// GetAllTargetMetadataByName searches the entire delegation role tree to find the specified target by name for all
+// roles, and returns a list of TargetSignedStructs for each time it finds the specified target.
+// If given an empty string for a target name, it will return back all targets signed into the repository in every role
+func (r *reader) GetAllTargetMetadataByName(name string) ([]TargetSignedStruct, error) {
+	var targetInfoList []TargetSignedStruct
+
+	// Define a visitor function to find the specified target
+	getAllTargetInfoByNameVisitorFunc := func(tgt *data.SignedTargets, validRole data.DelegationRole) interface{} {
+		if tgt == nil {
+			return nil
+		}
+		// We found a target and validated path compatibility in our walk,
+		// so add it to our list if we have a match
+		// if we have an empty name, add all targets, else check if we have it
+		var targetMetaToAdd data.Files
+		if name == "" {
+			targetMetaToAdd = tgt.Signed.Targets
+		} else {
+			if meta, ok := tgt.Signed.Targets[name]; ok {
+				targetMetaToAdd = data.Files{name: meta}
+			}
+		}
+
+		for targetName, resultMeta := range targetMetaToAdd {
+			targetInfo := TargetSignedStruct{
+				Role:       validRole,
+				Target:     Target{Name: targetName, Hashes: resultMeta.Hashes, Length: resultMeta.Length, Custom: resultMeta.Custom},
+				Signatures: tgt.Signatures,
+			}
+			targetInfoList = append(targetInfoList, targetInfo)
+		}
+		// continue walking to all child roles
+		return nil
+	}
+
+	// Check that we didn't error, and that we found the target at least once
+	if err := r.tufRepo.WalkTargets(name, "", getAllTargetInfoByNameVisitorFunc); err != nil {
+		return nil, err
+	}
+	if len(targetInfoList) == 0 {
+		return nil, ErrNoSuchTarget(name)
+	}
+	return targetInfoList, nil
+}
+
+// ListRoles returns a list of RoleWithSignatures objects for this repo
+// This represents the latest metadata for each role in this repo
+func (r *reader) ListRoles() ([]RoleWithSignatures, error) {
+	// Get all role info from our updated keysDB, can be empty
+	roles := r.tufRepo.GetAllLoadedRoles()
+
+	var roleWithSigs []RoleWithSignatures
+
+	// Populate RoleWithSignatures with Role from keysDB and signatures from TUF metadata
+	for _, role := range roles {
+		roleWithSig := RoleWithSignatures{Role: *role, Signatures: nil}
+		switch role.Name {
+		case data.CanonicalRootRole:
+			roleWithSig.Signatures = r.tufRepo.Root.Signatures
+		case data.CanonicalTargetsRole:
+			roleWithSig.Signatures = r.tufRepo.Targets[data.CanonicalTargetsRole].Signatures
+		case data.CanonicalSnapshotRole:
+			roleWithSig.Signatures = r.tufRepo.Snapshot.Signatures
+		case data.CanonicalTimestampRole:
+			roleWithSig.Signatures = r.tufRepo.Timestamp.Signatures
+		default:
+			if !data.IsDelegation(role.Name) {
+				continue
+			}
+			if _, ok := r.tufRepo.Targets[role.Name]; ok {
+				// We'll only find a signature if we've published any targets with this delegation
+				roleWithSig.Signatures = r.tufRepo.Targets[role.Name].Signatures
+			}
+		}
+		roleWithSigs = append(roleWithSigs, roleWithSig)
+	}
+	return roleWithSigs, nil
+}
+
+// GetDelegationRoles returns the keys and roles of the repository's delegations
+// Also converts key IDs to canonical key IDs to keep consistent with signing prompts
+func (r *reader) GetDelegationRoles() ([]data.Role, error) {
+	// All top level delegations (ex: targets/level1) are stored exclusively in targets.json
+	_, ok := r.tufRepo.Targets[data.CanonicalTargetsRole]
+	if !ok {
+		return nil, store.ErrMetaNotFound{Resource: data.CanonicalTargetsRole.String()}
+	}
+
+	// make a copy for traversing nested delegations
+	allDelegations := []data.Role{}
+
+	// Define a visitor function to populate the delegations list and translate their key IDs to canonical IDs
+	delegationCanonicalListVisitor := func(tgt *data.SignedTargets, validRole data.DelegationRole) interface{} {
+		// For the return list, update with a copy that includes canonicalKeyIDs
+		// These aren't validated by the validRole
+		canonicalDelegations, err := translateDelegationsToCanonicalIDs(tgt.Signed.Delegations)
+		if err != nil {
+			return err
+		}
+		allDelegations = append(allDelegations, canonicalDelegations...)
+		return nil
+	}
+	err := r.tufRepo.WalkTargets("", "", delegationCanonicalListVisitor)
+	if err != nil {
+		return nil, err
+	}
+	return allDelegations, nil
+}

--- a/client/tufclient.go
+++ b/client/tufclient.go
@@ -3,9 +3,11 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/sirupsen/logrus"
 	"github.com/theupdateframework/notary"
+	"github.com/theupdateframework/notary/cryptoservice"
 	store "github.com/theupdateframework/notary/storage"
 	"github.com/theupdateframework/notary/trustpinning"
 	"github.com/theupdateframework/notary/tuf"
@@ -19,16 +21,6 @@ type tufClient struct {
 	cache      store.MetadataStore
 	oldBuilder tuf.RepoBuilder
 	newBuilder tuf.RepoBuilder
-}
-
-// newTufClient initialized a tufClient with the given repo, remote source of content, and cache
-func newTufClient(oldBuilder, newBuilder tuf.RepoBuilder, remote store.RemoteStore, cache store.MetadataStore) *tufClient {
-	return &tufClient{
-		oldBuilder: oldBuilder,
-		newBuilder: newBuilder,
-		remote:     remote,
-		cache:      cache,
-	}
 }
 
 // Update performs an update to the TUF repo as defined by the TUF spec
@@ -322,4 +314,150 @@ func (c *tufClient) tryLoadRemote(consistentInfo tuf.ConsistentInfo, old []byte)
 		logrus.Debugf("Unable to write %s to cache: %s", consistentInfo.RoleName, err)
 	}
 	return raw, nil
+}
+
+// TUFLoadOptions are provided to LoadTUFRepo, which loads a TUF repo from cache,
+// from a remote store, or both
+type TUFLoadOptions struct {
+	GUN                    data.GUN
+	TrustPinning           trustpinning.TrustPinConfig
+	CryptoService          signed.CryptoService
+	Cache                  store.MetadataStore
+	RemoteStore            store.RemoteStore
+	AlwaysCheckInitialized bool
+}
+
+// bootstrapClient attempts to bootstrap a root.json to be used as the trust
+// anchor for a repository. The checkInitialized argument indicates whether
+// we should always attempt to contact the server to determine if the repository
+// is initialized or not. If set to true, we will always attempt to download
+// and return an error if the remote repository errors.
+//
+// Populates a tuf.RepoBuilder with this root metadata. If the root metadata
+// downloaded is a newer version than what is on disk, then intermediate
+// versions will be downloaded and verified in order to rotate trusted keys
+// properly. Newer root metadata must always be signed with the previous
+// threshold and keys.
+//
+// Fails if the remote server is reachable and does not know the repo
+// (i.e. before any metadata has been published), in which case the error is
+// store.ErrMetaNotFound, or if the root metadata (from whichever source is used)
+// is not trusted.
+//
+// Returns a TUFClient for the remote server, which may not be actually
+// operational (if the URL is invalid but a root.json is cached).
+func bootstrapClient(l TUFLoadOptions) (*tufClient, error) {
+	minVersion := 1
+	// the old root on disk should not be validated against any trust pinning configuration
+	// because if we have an old root, it itself is the thing that pins trust
+	oldBuilder := tuf.NewRepoBuilder(l.GUN, l.CryptoService, trustpinning.TrustPinConfig{})
+
+	// by default, we want to use the trust pinning configuration on any new root that we download
+	newBuilder := tuf.NewRepoBuilder(l.GUN, l.CryptoService, l.TrustPinning)
+
+	// Try to read root from cache first. We will trust this root until we detect a problem
+	// during update which will cause us to download a new root and perform a rotation.
+	// If we have an old root, and it's valid, then we overwrite the newBuilder to be one
+	// preloaded with the old root or one which uses the old root for trust bootstrapping.
+	if rootJSON, err := l.Cache.GetSized(data.CanonicalRootRole.String(), store.NoSizeLimit); err == nil {
+		// if we can't load the cached root, fail hard because that is how we pin trust
+		if err := oldBuilder.Load(data.CanonicalRootRole, rootJSON, minVersion, true); err != nil {
+			return nil, err
+		}
+
+		// again, the root on disk is the source of trust pinning, so use an empty trust
+		// pinning configuration
+		newBuilder = tuf.NewRepoBuilder(l.GUN, l.CryptoService, trustpinning.TrustPinConfig{})
+
+		if err := newBuilder.Load(data.CanonicalRootRole, rootJSON, minVersion, false); err != nil {
+			// Ok, the old root is expired - we want to download a new one.  But we want to use the
+			// old root to verify the new root, so bootstrap a new builder with the old builder
+			// but use the trustpinning to validate the new root
+			minVersion = oldBuilder.GetLoadedVersion(data.CanonicalRootRole)
+			newBuilder = oldBuilder.BootstrapNewBuilderWithNewTrustpin(l.TrustPinning)
+		}
+	}
+
+	if !newBuilder.IsLoaded(data.CanonicalRootRole) || l.AlwaysCheckInitialized {
+		// remoteErr was nil and we were not able to load a root from cache or
+		// are specifically checking for initialization of the repo.
+
+		// if remote store successfully set up, try and get root from remote
+		// We don't have any local data to determine the size of root, so try the maximum (though it is restricted at 100MB)
+		tmpJSON, err := l.RemoteStore.GetSized(data.CanonicalRootRole.String(), store.NoSizeLimit)
+		if err != nil {
+			// we didn't have a root in cache and were unable to load one from
+			// the server. Nothing we can do but error.
+			return nil, err
+		}
+
+		if !newBuilder.IsLoaded(data.CanonicalRootRole) {
+			// we always want to use the downloaded root if we couldn't load from cache
+			if err := newBuilder.Load(data.CanonicalRootRole, tmpJSON, minVersion, false); err != nil {
+				return nil, err
+			}
+
+			err = l.Cache.Set(data.CanonicalRootRole.String(), tmpJSON)
+			if err != nil {
+				// if we can't write cache we should still continue, just log error
+				logrus.Errorf("could not save root to cache: %s", err.Error())
+			}
+		}
+	}
+
+	// We can only get here if remoteErr != nil (hence we don't download any new root),
+	// and there was no root on disk
+	if !newBuilder.IsLoaded(data.CanonicalRootRole) {
+		return nil, ErrRepoNotInitialized{}
+	}
+
+	return &tufClient{
+		oldBuilder: oldBuilder,
+		newBuilder: newBuilder,
+		remote:     l.RemoteStore,
+		cache:      l.Cache,
+	}, nil
+}
+
+// LoadTUFRepo bootstraps a trust anchor (root.json) from cache (if provided) before updating
+// all the metadata for the repo from the remote (if provided). It loads a TUF repo from cache,
+// from a remote store, or both.
+func LoadTUFRepo(options TUFLoadOptions) (*tuf.Repo, *tuf.Repo, error) {
+	// set some sane defaults, so nothing has to be provided necessarily
+	if options.RemoteStore == nil {
+		options.RemoteStore = store.OfflineStore{}
+	}
+	if options.Cache == nil {
+		options.Cache = store.NewMemoryStore(nil)
+	}
+	if options.CryptoService == nil {
+		options.CryptoService = cryptoservice.EmptyService
+	}
+
+	c, err := bootstrapClient(options)
+	if err != nil {
+		if _, ok := err.(store.ErrMetaNotFound); ok {
+			return nil, nil, ErrRepositoryNotExist{
+				remote: options.RemoteStore.Location(),
+				gun:    options.GUN,
+			}
+		}
+		return nil, nil, err
+	}
+	repo, invalid, err := c.Update()
+	if err != nil {
+		// notFound.Resource may include a version or checksum so when the role is root,
+		// it will be root, <version>.root or root.<checksum>.
+		notFound, ok := err.(store.ErrMetaNotFound)
+		isRoot, _ := regexp.MatchString(`\.?`+data.CanonicalRootRole.String()+`\.?`, notFound.Resource)
+		if ok && isRoot {
+			return nil, nil, ErrRepositoryNotExist{
+				remote: options.RemoteStore.Location(),
+				gun:    options.GUN,
+			}
+		}
+		return nil, nil, err
+	}
+	warnRolesNearExpiry(repo)
+	return repo, invalid, nil
 }

--- a/cryptoservice/crypto_service.go
+++ b/cryptoservice/crypto_service.go
@@ -21,6 +21,9 @@ var (
 	// ErrRootKeyNotEncrypted is returned if a root key being imported is
 	// unencrypted
 	ErrRootKeyNotEncrypted = errors.New("only encrypted root keys may be imported")
+
+	// EmptyService is an empty crypto service
+	EmptyService = NewCryptoService()
 )
 
 // CryptoService implements Sign and Create, holding a specific GUN and keystore to

--- a/server/handlers/default_test.go
+++ b/server/handlers/default_test.go
@@ -413,7 +413,7 @@ func TestAtomicUpdateValidationFailurePropagated(t *testing.T) {
 }
 
 type failStore struct {
-	storage.MemStorage
+	storage.MetaStore
 }
 
 func (s *failStore) GetCurrent(_ data.GUN, _ data.RoleName) (*time.Time, []byte, error) {
@@ -430,7 +430,7 @@ func TestAtomicUpdateNonValidationFailureNotPropagated(t *testing.T) {
 	repo, cs, err := testutils.EmptyRepo(gun)
 	require.NoError(t, err)
 
-	state := handlerState{store: &failStore{*metaStore}, crypto: testutils.CopyKeys(t, cs, data.CanonicalTimestampRole)}
+	state := handlerState{store: &failStore{metaStore}, crypto: testutils.CopyKeys(t, cs, data.CanonicalTimestampRole)}
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
 	require.NoError(t, err)
@@ -455,7 +455,7 @@ func TestAtomicUpdateNonValidationFailureNotPropagated(t *testing.T) {
 }
 
 type invalidVersionStore struct {
-	storage.MemStorage
+	storage.MetaStore
 }
 
 func (s *invalidVersionStore) UpdateMany(_ data.GUN, _ []storage.MetaUpdate) error {
@@ -473,7 +473,7 @@ func TestAtomicUpdateVersionErrorPropagated(t *testing.T) {
 	require.NoError(t, err)
 
 	state := handlerState{
-		store: &invalidVersionStore{*metaStore}, crypto: testutils.CopyKeys(t, cs, data.CanonicalTimestampRole)}
+		store: &invalidVersionStore{metaStore}, crypto: testutils.CopyKeys(t, cs, data.CanonicalTimestampRole)}
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
 	require.NoError(t, err)

--- a/storage/httpstore.go
+++ b/storage/httpstore.go
@@ -111,6 +111,18 @@ type HTTPStore struct {
 	roundTrip     http.RoundTripper
 }
 
+// NewNotaryServerStore returns a new HTTPStore against a URL which should represent a notary
+// server
+func NewNotaryServerStore(serverURL string, gun data.GUN, roundTrip http.RoundTripper) (RemoteStore, error) {
+	return NewHTTPStore(
+		serverURL+"/v2/"+gun.String()+"/_trust/tuf/",
+		"",
+		"json",
+		"key",
+		roundTrip,
+	)
+}
+
 // NewHTTPStore initializes a new store against a URL and a number of configuration options.
 //
 // In case of a nil `roundTrip`, a default offline store is used instead.
@@ -363,5 +375,5 @@ func (s HTTPStore) RotateKey(role data.RoleName) ([]byte, error) {
 
 // Location returns a human readable name for the storage location
 func (s HTTPStore) Location() string {
-	return s.baseURL.String()
+	return s.baseURL.Host
 }

--- a/storage/httpstore_test.go
+++ b/storage/httpstore_test.go
@@ -409,3 +409,21 @@ func TestNetworkError(t *testing.T) {
 	networkErr3 := NetworkError{Wrapped: err3}
 	require.Equal(t, err3.Error(), networkErr3.Error())
 }
+
+func TestLocation(t *testing.T) {
+	s, err := NewNotaryServerStore("https://my.server.io", "myGUN", failRoundTripper{})
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	require.Equal(t, s.Location(), "my.server.io")
+
+	s, err = NewHTTPStore(
+		"http://store.me",
+		"metadata",
+		"txt",
+		"key",
+		failRoundTripper{},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	require.Equal(t, s.Location(), "store.me")
+}

--- a/storage/interfaces.go
+++ b/storage/interfaces.go
@@ -15,6 +15,7 @@ type MetadataStore interface {
 	SetMulti(map[string][]byte) error
 	RemoveAll() error
 	Remove(name string) error
+	Location() string
 }
 
 // PublicKeyStore must be implemented by a key service


### PR DESCRIPTION
Refactor the notary client library to have a separate reader and loader that may be easier to use for clients that do not need any publishing capabilities.

Originally proposed something similar in https://github.com/theupdateframework/notary/issues/968 - this just makes it easier to set up a downloading client that can read to an in-memory cache, or just something that will load from cache without having to provide a CryptoService, etc.

The plan is, if this PR passes design and code review, for a new PR converting all the `client_update_tests` to just use the `LoadTUFRepo` function and an in-memory cache.

cc @justincormack 