### PR TITLE
Fix gas check (was renamed to gosec)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN useradd -ms /bin/bash notary \
 	&& pip install codecov \
-	&& go get github.com/golang/lint/golint github.com/fzipp/gocyclo github.com/client9/misspell/cmd/misspell github.com/gordonklaus/ineffassign github.com/GoASTScanner/gas/cmd/gas/...
+	&& go get github.com/golang/lint/golint github.com/fzipp/gocyclo github.com/client9/misspell/cmd/misspell github.com/gordonklaus/ineffassign github.com/securego/gosec/cmd/gosec/...
 
 ENV NOTARYDIR /go/src/github.com/theupdateframework/notary
 

--- a/Makefile
+++ b/Makefile
@@ -113,9 +113,9 @@ endif
 	# ineffassign - requires that the following be run first:
 	#    go get -u github.com/gordonklaus/ineffassign
 	@test -z "$(shell find . -type f -name "*.go" -not -path "./vendor/*" -not -name "*.pb.*" -exec ineffassign {} \; | tee /dev/stderr)"
-	# gas - requires that the following be run first:
-	#    go get -u github.com/GoASTScanner/gas/cmd/gas/...
-	@gas -fmt=csv -out=gas_output.csv -exclude=G104,G304 ./... && test -z "$$(cat gas_output.csv | tee /dev/stderr)"
+	# gosec - requires that the following be run first:
+	#    go get -u github.com/securego/gosec/cmd/gosec/...
+	@gosec -fmt=csv -out=gas_output.csv -exclude=G104,G304 ./... && test -z "$$(cat gas_output.csv | tee /dev/stderr)"
 
 build:
 	@echo "+ $@"

--- a/cross.Dockerfile
+++ b/cross.Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN useradd -ms /bin/bash notary \
 	&& pip install codecov \
-	&& go get github.com/golang/lint/golint github.com/fzipp/gocyclo github.com/client9/misspell/cmd/misspell github.com/gordonklaus/ineffassign github.com/GoASTScanner/gas/cmd/gas/...
+	&& go get github.com/golang/lint/golint github.com/fzipp/gocyclo github.com/client9/misspell/cmd/misspell github.com/gordonklaus/ineffassign github.com/securego/gosec/cmd/gosec/...
 
 # Configure the container for OSX cross compilation
 ENV OSX_SDK MacOSX10.11.sdk


### PR DESCRIPTION
`github.com/GoASTScanner/gas` has been renamed to `github.com/securego/gosec`, and the executable also renamed `gosec`.  

This PR fixes all the imports/installs so that CI works again.

cc @justincormack 