### PR TITLE
Add import of sha1 to gosec whitelist

### DIFF
--- a/tuf/utils/pkcs8.go
+++ b/tuf/utils/pkcs8.go
@@ -39,7 +39,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha1"
+	"crypto/sha1" // #nosec
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"


### PR DESCRIPTION
The code checker, gosec, has started flagging the import of crypto/sha1
as potentially weak crypto. It is being used as the hash function for
PBKDF2 when keys are password protected.

In the short term I think removing the warning is fine as it restores
the status quo; need to look further if we really need this code.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>