### PR TITLE
Clarify maintainer rules

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -31,7 +31,7 @@
 
 	[people.cyli]
 	Name = "Ying Li"
-	Email = "ying.li@docker.com"
+	Email = "cyli@twistedmatrix.com"
 	GitHub = "cyli"
 
 	[people.diogomonica]

--- a/MAINTAINERS_RULES.md
+++ b/MAINTAINERS_RULES.md
@@ -23,7 +23,7 @@ Changes to the [Repo Guidelines](#repo-guidelines) require a simple majority.
 - Invitation is proposed by an existing maintainer.
 - Ceiling(two-thirds) supermajority approval from existing maintainers (including vote of proposing maintainer) required to accept proposal.
 - Newly approved maintainer submits PR adding themselves to the MAINTAINERS file.
-- Existing maintainers publicly mark their approval on the PR.
+- Existing maintainers (again, two-thirds) publicly mark their approval on the PR.
 - Existing maintainer updates repository permissions to grant write access to new maintainer.
 - New maintainer merges their PR.
 


### PR DESCRIPTION
As @eiais pointed out and @endophage clarified in #1379, 2/3 supermajority of maintainers must approve a maintainer PR before it can be merged.

This PR updates the docs to specify, and while I'm at it update my email address.