### PR TITLE
Update to Go 1.11.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3
+FROM golang:1.11.2
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/client/client.go
+++ b/client/client.go
@@ -981,7 +981,7 @@ func DeleteTrustData(baseDir string, gun data.GUN, URL string, rt http.RoundTrip
 	if deleteRemote {
 		remote, err := getRemoteStore(URL, gun, rt)
 		if err != nil {
-			logrus.Error("unable to instantiate a remote store: %v", err)
+			logrus.Errorf("unable to instantiate a remote store: %v", err)
 			return err
 		}
 		if err := remote.RemoveAll(); err != nil {

--- a/client/tufclient.go
+++ b/client/tufclient.go
@@ -131,7 +131,7 @@ func (c *tufClient) updateRoot() error {
 
 	// Write newest to cache
 	if err := c.cache.Set(data.CanonicalRootRole.String(), raw); err != nil {
-		logrus.Debugf("unable to write %s to cache: %d.%s", newestVersion, data.CanonicalRootRole, err)
+		logrus.Debugf("unable to write %d.%s to cache: %s", newestVersion, data.CanonicalRootRole, err)
 	}
 	logrus.Debugf("finished updating root files")
 	return nil

--- a/cmd/notary-server/main_test.go
+++ b/cmd/notary-server/main_test.go
@@ -380,9 +380,9 @@ func TestGetCacheConfig(t *testing.T) {
 
 func TestGetGUNPRefixes(t *testing.T) {
 	valids := map[string][]string{
-		`{}`: nil,
-		`{"repositories": {"gun_prefixes": []}}`:         nil,
-		`{"repositories": {}}`:                           nil,
+		`{}`:                                     nil,
+		`{"repositories": {"gun_prefixes": []}}`: nil,
+		`{"repositories": {}}`:                   nil,
 		`{"repositories": {"gun_prefixes": ["hello/"]}}`: {"hello/"},
 	}
 	invalids := []string{

--- a/cross.Dockerfile
+++ b/cross.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3
+FROM golang:1.11.2
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/escrow.Dockerfile
+++ b/escrow.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3-alpine
+FROM golang:1.11.2-alpine
 
 ENV NOTARYPKG github.com/theupdateframework/notary
 

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3-alpine
+FROM golang:1.11.2-alpine
 
 RUN apk add --update git gcc libc-dev
 

--- a/server.minimal.Dockerfile
+++ b/server.minimal.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3-alpine AS build-env
+FROM golang:1.11.2-alpine AS build-env
 RUN apk add --update git gcc libc-dev
 # Pin to the specific v3.0.0 version
 RUN go get -tags 'mysql postgres file' github.com/mattes/migrate/cli && mv /go/bin/cli /go/bin/migrate

--- a/signer.Dockerfile
+++ b/signer.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3-alpine
+FROM golang:1.11.2-alpine
 
 RUN apk add --update git gcc libc-dev
 

--- a/signer.minimal.Dockerfile
+++ b/signer.minimal.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3-alpine AS build-env
+FROM golang:1.11.2-alpine AS build-env
 RUN apk add --update git gcc libc-dev
 # Pin to the specific v3.0.0 version
 RUN go get -tags 'mysql postgres file' github.com/mattes/migrate/cli && mv /go/bin/cli /go/bin/migrate

--- a/tuf/data/roles_test.go
+++ b/tuf/data/roles_test.go
@@ -111,8 +111,8 @@ func TestIsDelegation(t *testing.T) {
 	for val, check := range map[string]func(require.TestingT, bool, ...interface{}){
 		// false checks
 		path.Join(CanonicalTargetsRole.String(), strings.Repeat("x", 255-len(CanonicalTargetsRole.String()))): f,
-		"": f,
-		CanonicalRootRole.String():                                                                            f,
+		"":                         f,
+		CanonicalRootRole.String(): f,
 		path.Join(CanonicalRootRole.String(), "level1"):                                                       f,
 		CanonicalTargetsRole.String():                                                                         f,
 		CanonicalTargetsRole.String() + "/":                                                                   f,
@@ -143,12 +143,12 @@ func TestIsWildDelegation(t *testing.T) {
 	tr := require.True
 	for val, check := range map[string]func(require.TestingT, bool, ...interface{}){
 		// false checks
-		CanonicalRootRole.String():      f,
-		CanonicalTargetsRole.String():   f,
-		CanonicalSnapshotRole.String():  f,
-		CanonicalTimestampRole.String(): f,
-		"foo":   f,
-		"foo/*": f,
+		CanonicalRootRole.String():                           f,
+		CanonicalTargetsRole.String():                        f,
+		CanonicalSnapshotRole.String():                       f,
+		CanonicalTimestampRole.String():                      f,
+		"foo":                                                f,
+		"foo/*":                                              f,
 		path.Join(CanonicalRootRole.String(), "*"):           f,
 		path.Join(CanonicalSnapshotRole.String(), "*"):       f,
 		path.Join(CanonicalTimestampRole.String(), "*"):      f,


### PR DESCRIPTION
Includes minor changes to `go fmt` and fixes for some errors that
the updated linter picked up.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>