### PR TITLE
Update to Go 1.10.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3
+FROM golang:1.10.8
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/cross.Dockerfile
+++ b/cross.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3
+FROM golang:1.10.8
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/escrow.Dockerfile
+++ b/escrow.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3-alpine
+FROM golang:1.10.8-alpine
 
 ENV NOTARYPKG github.com/theupdateframework/notary
 

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3-alpine
+FROM golang:1.10.8-alpine
 
 RUN apk add --update git gcc libc-dev
 

--- a/server.minimal.Dockerfile
+++ b/server.minimal.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3-alpine AS build-env
+FROM golang:1.10.8-alpine AS build-env
 RUN apk add --update git gcc libc-dev
 # Pin to the specific v3.0.0 version
 RUN go get -tags 'mysql postgres file' github.com/mattes/migrate/cli && mv /go/bin/cli /go/bin/migrate

--- a/signer.Dockerfile
+++ b/signer.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3-alpine
+FROM golang:1.10.8-alpine
 
 RUN apk add --update git gcc libc-dev
 

--- a/signer.minimal.Dockerfile
+++ b/signer.minimal.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3-alpine AS build-env
+FROM golang:1.10.8-alpine AS build-env
 RUN apk add --update git gcc libc-dev
 # Pin to the specific v3.0.0 version
 RUN go get -tags 'mysql postgres file' github.com/mattes/migrate/cli && mv /go/bin/cli /go/bin/migrate


### PR DESCRIPTION
Includes denial of service fix on TLS connections, and other security fixes.

1.10.7 images are not out yet, and 1.10.6 has a bug so that breaks build, so need to wait for 1.10.7 images.