### PR TITLE
Bump golang 1.11, and switch to dockercore/golang-cross for cross-compiling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.8
+FROM golang:1.11.2
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.2
+FROM golang:1.11.5
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/cmd/notary-server/main_test.go
+++ b/cmd/notary-server/main_test.go
@@ -380,9 +380,9 @@ func TestGetCacheConfig(t *testing.T) {
 
 func TestGetGUNPRefixes(t *testing.T) {
 	valids := map[string][]string{
-		`{}`: nil,
-		`{"repositories": {"gun_prefixes": []}}`:         nil,
-		`{"repositories": {}}`:                           nil,
+		`{}`:                                     nil,
+		`{"repositories": {"gun_prefixes": []}}`: nil,
+		`{"repositories": {}}`:                   nil,
 		`{"repositories": {"gun_prefixes": ["hello/"]}}`: {"hello/"},
 	}
 	invalids := []string{

--- a/cross.Dockerfile
+++ b/cross.Dockerfile
@@ -1,10 +1,9 @@
-FROM golang:1.10.8
+FROM dockercore/golang-cross:1.10.8
 
 RUN apt-get update && apt-get install -y \
 	curl \
 	clang \
 	file \
-	libltdl-dev \
 	libsqlite3-dev \
 	patch \
 	tar \
@@ -17,17 +16,6 @@ RUN apt-get update && apt-get install -y \
 RUN useradd -ms /bin/bash notary \
 	&& pip install codecov \
 	&& go get golang.org/x/lint/golint github.com/fzipp/gocyclo github.com/client9/misspell/cmd/misspell github.com/gordonklaus/ineffassign github.com/securego/gosec/cmd/gosec/...
-
-# Configure the container for OSX cross compilation
-ENV OSX_SDK MacOSX10.11.sdk
-ENV OSX_CROSS_COMMIT 1a1733a773fe26e7b6c93b16fbf9341f22fac831
-RUN set -x \
-	&& export OSXCROSS_PATH="/osxcross" \
-	&& git clone https://github.com/tpoechtrager/osxcross.git $OSXCROSS_PATH \
-	&& ( cd $OSXCROSS_PATH && git checkout -q $OSX_CROSS_COMMIT) \
-	&& curl -sSL https://s3.dockerproject.org/darwin/v2/${OSX_SDK}.tar.xz -o "${OSXCROSS_PATH}/tarballs/${OSX_SDK}.tar.xz" \
-	&& UNATTENDED=yes OSX_VERSION_MIN=10.6 ${OSXCROSS_PATH}/build.sh > /dev/null
-ENV PATH /osxcross/target/bin:$PATH
 
 ENV NOTARYDIR /go/src/github.com/theupdateframework/notary
 

--- a/cross.Dockerfile
+++ b/cross.Dockerfile
@@ -1,4 +1,4 @@
-FROM dockercore/golang-cross:1.11.2
+FROM dockercore/golang-cross:1.11.5
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/cross.Dockerfile
+++ b/cross.Dockerfile
@@ -1,4 +1,4 @@
-FROM dockercore/golang-cross:1.10.8
+FROM dockercore/golang-cross:1.11.2
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/escrow.Dockerfile
+++ b/escrow.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.8-alpine
+FROM golang:1.11.2-alpine
 
 ENV NOTARYPKG github.com/theupdateframework/notary
 

--- a/escrow.Dockerfile
+++ b/escrow.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.2-alpine
+FROM golang:1.11.5-alpine
 
 ENV NOTARYPKG github.com/theupdateframework/notary
 

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.8-alpine
+FROM golang:1.11.2-alpine
 
 RUN apk add --update git gcc libc-dev
 

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.2-alpine
+FROM golang:1.11.5-alpine
 
 RUN apk add --update git gcc libc-dev
 

--- a/server.minimal.Dockerfile
+++ b/server.minimal.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.2-alpine AS build-env
+FROM golang:1.11.5-alpine AS build-env
 RUN apk add --update git gcc libc-dev
 # Pin to the specific v3.0.0 version
 RUN go get -tags 'mysql postgres file' github.com/mattes/migrate/cli && mv /go/bin/cli /go/bin/migrate

--- a/server.minimal.Dockerfile
+++ b/server.minimal.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.8-alpine AS build-env
+FROM golang:1.11.2-alpine AS build-env
 RUN apk add --update git gcc libc-dev
 # Pin to the specific v3.0.0 version
 RUN go get -tags 'mysql postgres file' github.com/mattes/migrate/cli && mv /go/bin/cli /go/bin/migrate

--- a/signer.Dockerfile
+++ b/signer.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.8-alpine
+FROM golang:1.11.2-alpine
 
 RUN apk add --update git gcc libc-dev
 

--- a/signer.Dockerfile
+++ b/signer.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.2-alpine
+FROM golang:1.11.5-alpine
 
 RUN apk add --update git gcc libc-dev
 

--- a/signer.minimal.Dockerfile
+++ b/signer.minimal.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.2-alpine AS build-env
+FROM golang:1.11.5-alpine AS build-env
 RUN apk add --update git gcc libc-dev
 # Pin to the specific v3.0.0 version
 RUN go get -tags 'mysql postgres file' github.com/mattes/migrate/cli && mv /go/bin/cli /go/bin/migrate

--- a/signer.minimal.Dockerfile
+++ b/signer.minimal.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.8-alpine AS build-env
+FROM golang:1.11.2-alpine AS build-env
 RUN apk add --update git gcc libc-dev
 # Pin to the specific v3.0.0 version
 RUN go get -tags 'mysql postgres file' github.com/mattes/migrate/cli && mv /go/bin/cli /go/bin/migrate

--- a/tuf/data/roles_test.go
+++ b/tuf/data/roles_test.go
@@ -111,8 +111,8 @@ func TestIsDelegation(t *testing.T) {
 	for val, check := range map[string]func(require.TestingT, bool, ...interface{}){
 		// false checks
 		path.Join(CanonicalTargetsRole.String(), strings.Repeat("x", 255-len(CanonicalTargetsRole.String()))): f,
-		"": f,
-		CanonicalRootRole.String():                                                                            f,
+		"":                         f,
+		CanonicalRootRole.String(): f,
 		path.Join(CanonicalRootRole.String(), "level1"):                                                       f,
 		CanonicalTargetsRole.String():                                                                         f,
 		CanonicalTargetsRole.String() + "/":                                                                   f,
@@ -143,12 +143,12 @@ func TestIsWildDelegation(t *testing.T) {
 	tr := require.True
 	for val, check := range map[string]func(require.TestingT, bool, ...interface{}){
 		// false checks
-		CanonicalRootRole.String():      f,
-		CanonicalTargetsRole.String():   f,
-		CanonicalSnapshotRole.String():  f,
-		CanonicalTimestampRole.String(): f,
-		"foo":   f,
-		"foo/*": f,
+		CanonicalRootRole.String():                           f,
+		CanonicalTargetsRole.String():                        f,
+		CanonicalSnapshotRole.String():                       f,
+		CanonicalTimestampRole.String():                      f,
+		"foo":                                                f,
+		"foo/*":                                              f,
 		path.Join(CanonicalRootRole.String(), "*"):           f,
 		path.Join(CanonicalSnapshotRole.String(), "*"):       f,
 		path.Join(CanonicalTimestampRole.String(), "*"):      f,


### PR DESCRIPTION
Alternative to https://github.com/theupdateframework/notary/pull/1396, but let me know if it's acceptable to switch to a different base-image (instead of the official Go image)

Added an extra commit to switch to the golang-cross image, and rebased @justincormack's PR on that, then bumped Go to 1.11.5

Note that the version built on Go 1.11 requires `libtool` to be installed on macOS in order to run the binary;

On Go 1.10:

```
otool -L ./cross/darwin/amd64/notary
./cross/darwin/amd64/notary:
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1253.0.0)
	/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 57336.1.9)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1225.1.1)
```

On Go 1.11:

```
otool -L ./cross/darwin/amd64/notary
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1151.16.0)
	/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 57031.1.34)
	@@HOMEBREW_PREFIX@@/lib/libltdl.7.dylib (compatibility version 11.0.0, current version 11.1.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1213.0.0)
```

```
./cross/darwin/amd64/notary version
dyld: Library not loaded: @@HOMEBREW_PREFIX@@/lib/libltdl.7.dylib
  Referenced from: /Users/sebastiaan/go/src/github.com/theupdateframework/notary/./cross/darwin/amd64/notary
  Reason: image not found
```

Installing libtool resolves that;

```
brew install libtool

./cross/darwin/amd64/notary version
notary
 Version:    0.6.1
 Git commit: 1d28d8ae
```


