### PR TITLE
Fix some typos in markdown docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## [v0.6.1](https://github.com/docker/notary/releases/tag/v0.6.0) 04/10/2018
 + Fixed bug where CLI requested admin privileges for all metadata operations, including listing targets on a repo [#1315](https://github.com/theupdateframework/notary/pull/1315)
-+ Prevented notary signer from being dumpable or ptraceable in Linux, except in debug mode [#1327](https://github.com/theupdateframework/notary/pull/1327)
++ Prevented notary signer from being dumpable or being ptraced in Linux, except in debug mode [#1327](https://github.com/theupdateframework/notary/pull/1327)
 + Bumped JWT dependency to fix potential Invalid Curve Attack on NIST curves within ECDH key management [#1334](https://github.com/theupdateframework/notary/pull/1334)
 + If the home directory cannot be found, log a warning instead of erroring out [#1318](https://github.com/theupdateframework/notary/pull/1318)
 + Bumped go version and various dependencies [#1323](https://github.com/theupdateframework/notary/pull/1323) [#1332](https://github.com/theupdateframework/notary/pull/1332) [#1335](https://github.com/theupdateframework/notary/pull/1335) [#1336](https://github.com/theupdateframework/notary/pull/1336)

--- a/MAINTAINERS_RULES.md
+++ b/MAINTAINERS_RULES.md
@@ -29,7 +29,7 @@ Changes to the [Repo Guidelines](#repo-guidelines) require a simple majority.
 
 ## Removing maintainers
 
-It is preferrable that a maintainer gracefully removes themselves from the MAINTAINERS file if they are
+It is preferable that a maintainer gracefully removes themselves from the MAINTAINERS file if they are
 aware they will no longer have the time or motivation to contribute to the project. Maintainers that
 have been inactive in the repo for a period of at least one year should be contacted to ask if they
 wish to be removed.


### PR DESCRIPTION
1. "ptraceable" to "traceable" in line 5.
2. "preferrable" to "preferable" in line 32.