### PR TITLE
client: fix logger format types for variables

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -981,7 +981,7 @@ func DeleteTrustData(baseDir string, gun data.GUN, URL string, rt http.RoundTrip
 	if deleteRemote {
 		remote, err := getRemoteStore(URL, gun, rt)
 		if err != nil {
-			logrus.Error("unable to instantiate a remote store: %v", err)
+			logrus.Errorf("unable to instantiate a remote store: %v", err)
 			return err
 		}
 		if err := remote.RemoveAll(); err != nil {

--- a/client/tufclient.go
+++ b/client/tufclient.go
@@ -131,7 +131,7 @@ func (c *tufClient) updateRoot() error {
 
 	// Write newest to cache
 	if err := c.cache.Set(data.CanonicalRootRole.String(), raw); err != nil {
-		logrus.Debugf("unable to write %s to cache: %d.%s", newestVersion, data.CanonicalRootRole, err)
+		logrus.Debugf("unable to write %d.%s to cache: %s", newestVersion, data.CanonicalRootRole, err)
 	}
 	logrus.Debugf("finished updating root files")
 	return nil


### PR DESCRIPTION
This commit fixes the format specifier type for logging statements.

Inspired by: https://github.com/theupdateframework/notary/issues/1070


Signed-off-by: Simarpreet Singh <simar@linux.com>