### PR TITLE
Update deprecated links

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For more advanced usage, see the
 
 To use the CLI against a local Notary server rather than against Docker Hub:
 
-1. Ensure that you have [docker and docker-compose](http://docs.docker.com/compose/install/) installed.
+1. Ensure that you have [docker and docker-compose](https://docs.docker.com/compose/install/) installed.
 1. `git clone https://github.com/theupdateframework/notary.git` and from the cloned repository path,
     start up a local Notary server and signer and copy the config file and testing certs to your
     local Notary config directory:
@@ -108,7 +108,7 @@ Prerequisites:
     - Ubuntu: `apt-get install libltdl-dev`
     - CentOS/RedHat: `yum install libtool-ltdl-devel`
     - Fedora: `dnf install libtool-ltdl-devel`
-    - Mac OS ([Homebrew](http://brew.sh/)): `brew install libtool`
+    - Mac OS ([Homebrew](https://brew.sh)): `brew install libtool`
 
 Set [```GOPATH```](https://golang.org/doc/code.html#GOPATH). Then, run:
 

--- a/buildscripts/env.list
+++ b/buildscripts/env.list
@@ -28,7 +28,7 @@ BUILD_URL
 WORKSPACE
 
 # These are the Travis environment variables to pass through for codecov
-# http://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
+# https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
 # TRAVIS
 # TRAVIS_BRANCH
 # TRAVIS_JOB_NUMBER

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ draft = true
 
 # Contributing to the Docker Notary documentation
 
-The documentation in this directory is part of the [https://docs.docker.com](https://docs.docker.com) website.  Docker uses [the Hugo static generator](http://gohugo.io/overview/introduction/) to convert project Markdown files to a static HTML site. 
+The documentation in this directory is part of the [https://docs.docker.com](https://docs.docker.com) website.  Docker uses [the Hugo static generator](https://gohugo.io/getting-started/) to convert project Markdown files to a static HTML site.
 
 You don't need to be a Hugo expert to contribute to the Notary documentation. If you are familiar with Markdown, you can modify the content in the `docs` files.  
 

--- a/docs/service_architecture.md
+++ b/docs/service_architecture.md
@@ -104,7 +104,7 @@ server, and signer:
 ![Notary Service Sequence Diagram](https://cdn.rawgit.com/theupdateframework/notary/27469f01fe244bdf70f34219616657b336724bc3/docs/images/metadata-sequence.svg)
 
 1. Notary server optionally supports authentication from clients using
-   <a href="http://jwt.io/" target="_blank">JWT</a> tokens. This requires an authorization server that
+   <a href="https://jwt.io" target="_blank">JWT</a> tokens. This requires an authorization server that
    manages access controls, and a cert bundle from this authorization server
    containing the public key it uses to sign tokens.
 

--- a/notarysql/postgresql-initdb.d/pg_hba.conf
+++ b/notarysql/postgresql-initdb.d/pg_hba.conf
@@ -1,2 +1,2 @@
-# http://stackoverflow.com/q/18497299
+# https://stackoverflow.com/questions/18497299/psql-fatal-connection-requires-a-valid-client-certificate
 hostssl  all  all  0.0.0.0/0  cert clientcert=1


### PR DESCRIPTION
This PR replaces old HTTP links in various places (eg: README, docs ...) by secure, correct HTTPS links.