### PR TITLE
Remove the duplicated words in code comments

### DIFF
--- a/tuf/builder.go
+++ b/tuf/builder.go
@@ -359,7 +359,7 @@ func (rb *repoBuilder) GenerateSnapshot(prev *data.SignedSnapshot) ([]byte, int,
 
 	// loadedNotChecksummed should currently contain the root awaiting checksumming,
 	// since it has to have been loaded.  Since the snapshot was generated using
-	// the root and targets data (there may not be any) that that have been loaded,
+	// the root and targets data (there may not be any) that have been loaded,
 	// remove all of them from rb.loadedNotChecksummed
 	for tgtName := range rb.repo.Targets {
 		delete(rb.loadedNotChecksummed, data.RoleName(tgtName))

--- a/tuf/data/roles.go
+++ b/tuf/data/roles.go
@@ -55,7 +55,7 @@ func (e ErrInvalidRole) Error() string {
 
 // ValidRole only determines the name is semantically
 // correct. For target delegated roles, it does NOT check
-// the the appropriate parent roles exist.
+// the appropriate parent roles exist.
 func ValidRole(name RoleName) bool {
 	if IsDelegation(name) {
 		return true

--- a/tuf/utils/utils.go
+++ b/tuf/utils/utils.go
@@ -30,7 +30,7 @@ func RoleNameSliceContains(ss []data.RoleName, s data.RoleName) bool {
 	return false
 }
 
-// RoleNameSliceRemove removes the the given RoleName from the slice, returning a new slice
+// RoleNameSliceRemove removes the given RoleName from the slice, returning a new slice
 func RoleNameSliceRemove(ss []data.RoleName, s data.RoleName) []data.RoleName {
 	res := []data.RoleName{}
 	for _, v := range ss {

--- a/utils/auth_test.go
+++ b/utils/auth_test.go
@@ -24,7 +24,7 @@ func (ac TestingAccessController) Authorized(ctx context.Context, access ...auth
 
 // TestingAuthChallenge is for TEST USE ONLY!!!
 // It implements the auth.Challenge interface and allows a test to confirm
-// the the SetHeaders method was called.
+// the SetHeaders method was called.
 type TestingAuthChallenge struct {
 	SetHeadersCalled bool
 }


### PR DESCRIPTION
Although it is spelling mistakes, it might make an affects while reading.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>