### PR TITLE
Adding `/usr/bin/env bash`

### DIFF
--- a/migrations/rethink_migrate.sh
+++ b/migrations/rethink_migrate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # When run in the docker containers, the working directory
 # is the root of the repo.

--- a/notarysql/postgresql-initdb.d/tls-setup.sh
+++ b/notarysql/postgresql-initdb.d/tls-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # Setup the server so it knows where to find certs so that server can be
 # started with TLS enabled.


### PR DESCRIPTION
This commit aims to add `/usr/bin/env bash` as a shebang line
to indicates scripts use bash shell for interpreting.

Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>