### PR TITLE
Change http to https for security links

### DIFF
--- a/trustmanager/importLogic.md
+++ b/trustmanager/importLogic.md
@@ -2,7 +2,7 @@
 
 # A flowchart to detail the logic of our import function in `utils/keys.go` (`func ImportKeys`)
 
-![alt text](http://i.imgur.com/HQICWeO.png "Flowchart of key import logic")
+![alt text](https://i.imgur.com/HQICWeO.png "Flowchart of key import logic")
 
 ### Should this logic change, you can edit this image at `https://www.draw.io/i/HQICWeO`
 


### PR DESCRIPTION
For security, we should change http into https links.