### PR TITLE
Fix #1473

### DIFF
--- a/tuf/utils/x509.go
+++ b/tuf/utils/x509.go
@@ -485,6 +485,7 @@ func ConvertPrivateKeyToPKCS8(key data.PrivateKey, role data.RoleName, gun data.
 		headers["gun"] = gun.String()
 	}
 
+	headers["path"] = key.ID()
 	return pem.EncodeToMemory(&pem.Block{Bytes: der, Type: blockType, Headers: headers}), nil
 }
 


### PR DESCRIPTION
Fix #1473 

Note that `ConvertPrivateKeyToPKCS8` is called in a number of (other) places (not only `generate`).

I can't think of a reason why the additional PEM header would hurt, but then, somebody with a better understanding of the codebase should check.