### PR TITLE
Bump golang 1.12.10 (CVE-2019-9512, CVE-2019-9514, CVE-2019-16276)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.7
+FROM golang:1.12.10
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/cross.Dockerfile
+++ b/cross.Dockerfile
@@ -1,4 +1,4 @@
-FROM dockercore/golang-cross:1.11.5
+FROM dockercore/golang-cross:1.12.10
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/escrow.Dockerfile
+++ b/escrow.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.5-alpine
+FROM golang:1.12.10-alpine
 
 ENV NOTARYPKG github.com/theupdateframework/notary
 

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,7 +1,7 @@
 # Database Migrations
 
 This directory contains database migrations for the server and signer. They
-are being managed using [this tool](https://github.com/mattes/migrate).
+are being managed using [this tool](https://github.com/golang-migrate/migrate).
 Within each of the server and signer directories are directories for different
 database backends. Notary server and signer use GORM and are therefore 
 capable of running on a number of different databases, however migrations

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.11.5-alpine
 RUN apk add --update git gcc libc-dev
 
 # Pin to the specific v3.0.0 version
-RUN go get -tags 'mysql postgres file' github.com/mattes/migrate/cli && mv /go/bin/cli /go/bin/migrate
+RUN go get -tags 'mysql postgres file' github.com/golang-migrate/migrate/cli && mv /go/bin/cli /go/bin/migrate
 
 ENV NOTARYPKG github.com/theupdateframework/notary
 

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.5-alpine
+FROM golang:1.12.10-alpine
 
 RUN apk add --update git gcc libc-dev
 

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -2,8 +2,8 @@ FROM golang:1.11.5-alpine
 
 RUN apk add --update git gcc libc-dev
 
-# Pin to the specific v3.0.0 version
-RUN go get -tags 'mysql postgres file' github.com/golang-migrate/migrate/cli && mv /go/bin/cli /go/bin/migrate
+ARG MIGRATE_VER=v4.6.2
+RUN GO111MODULE=on go get -tags 'mysql postgres file' github.com/golang-migrate/migrate/v4/cli@${MIGRATE_VER} && mv /go/bin/cli /go/bin/migrate
 
 ENV NOTARYPKG github.com/theupdateframework/notary
 

--- a/server.minimal.Dockerfile
+++ b/server.minimal.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.5-alpine AS build-env
+FROM golang:1.12.10-alpine AS build-env
 RUN apk add --update git gcc libc-dev
 
 ARG MIGRATE_VER=v4.6.2

--- a/server.minimal.Dockerfile
+++ b/server.minimal.Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.11.5-alpine AS build-env
 RUN apk add --update git gcc libc-dev
 # Pin to the specific v3.0.0 version
-RUN go get -tags 'mysql postgres file' github.com/mattes/migrate/cli && mv /go/bin/cli /go/bin/migrate
+RUN go get -tags 'mysql postgres file' github.com/golang-migrate/migrate/cli && mv /go/bin/cli /go/bin/migrate
 
 ENV NOTARYPKG github.com/theupdateframework/notary
 

--- a/server.minimal.Dockerfile
+++ b/server.minimal.Dockerfile
@@ -1,7 +1,8 @@
 FROM golang:1.11.5-alpine AS build-env
 RUN apk add --update git gcc libc-dev
-# Pin to the specific v3.0.0 version
-RUN go get -tags 'mysql postgres file' github.com/golang-migrate/migrate/cli && mv /go/bin/cli /go/bin/migrate
+
+ARG MIGRATE_VER=v4.6.2
+RUN GO111MODULE=on go get -tags 'mysql postgres file' github.com/golang-migrate/migrate/v4/cli@${MIGRATE_VER} && mv /go/bin/cli /go/bin/migrate
 
 ENV NOTARYPKG github.com/theupdateframework/notary
 

--- a/signer.Dockerfile
+++ b/signer.Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.11.5-alpine
 RUN apk add --update git gcc libc-dev
 
 # Pin to the specific v3.0.0 version
-RUN go get -tags 'mysql postgres file' github.com/mattes/migrate/cli && mv /go/bin/cli /go/bin/migrate
+RUN go get -tags 'mysql postgres file' github.com/golang-migrate/migrate/cli && mv /go/bin/cli /go/bin/migrate
 
 ENV NOTARYPKG github.com/theupdateframework/notary
 

--- a/signer.Dockerfile
+++ b/signer.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.5-alpine
+FROM golang:1.12.10-alpine
 
 RUN apk add --update git gcc libc-dev
 

--- a/signer.Dockerfile
+++ b/signer.Dockerfile
@@ -2,8 +2,8 @@ FROM golang:1.11.5-alpine
 
 RUN apk add --update git gcc libc-dev
 
-# Pin to the specific v3.0.0 version
-RUN go get -tags 'mysql postgres file' github.com/golang-migrate/migrate/cli && mv /go/bin/cli /go/bin/migrate
+ARG MIGRATE_VER=v4.6.2
+RUN GO111MODULE=on go get -tags 'mysql postgres file' github.com/golang-migrate/migrate/v4/cli@${MIGRATE_VER} && mv /go/bin/cli /go/bin/migrate
 
 ENV NOTARYPKG github.com/theupdateframework/notary
 

--- a/signer.minimal.Dockerfile
+++ b/signer.minimal.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.5-alpine AS build-env
+FROM golang:1.12.10-alpine AS build-env
 RUN apk add --update git gcc libc-dev
 
 ARG MIGRATE_VER=v4.6.2

--- a/signer.minimal.Dockerfile
+++ b/signer.minimal.Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.11.5-alpine AS build-env
 RUN apk add --update git gcc libc-dev
 # Pin to the specific v3.0.0 version
-RUN go get -tags 'mysql postgres file' github.com/mattes/migrate/cli && mv /go/bin/cli /go/bin/migrate
+RUN go get -tags 'mysql postgres file' github.com/golang-migrate/migrate/cli && mv /go/bin/cli /go/bin/migrate
 
 ENV NOTARYPKG github.com/theupdateframework/notary
 

--- a/signer.minimal.Dockerfile
+++ b/signer.minimal.Dockerfile
@@ -1,7 +1,9 @@
 FROM golang:1.11.5-alpine AS build-env
 RUN apk add --update git gcc libc-dev
-# Pin to the specific v3.0.0 version
-RUN go get -tags 'mysql postgres file' github.com/golang-migrate/migrate/cli && mv /go/bin/cli /go/bin/migrate
+
+ARG MIGRATE_VER=v4.6.2
+RUN GO111MODULE=on go get -tags 'mysql postgres file' github.com/golang-migrate/migrate/v4/cli@${MIGRATE_VER} && mv /go/bin/cli /go/bin/migrate
+
 
 ENV NOTARYPKG github.com/theupdateframework/notary
 


### PR DESCRIPTION
Bump golang 1.12.10 (CVE-2019-16276)
=====================================================

go1.12.10 (released 2019/09/25) includes security fixes to the net/http and net/textproto
packages. See the Go 1.12.10 milestone on our issue tracker for details.

https://github.com/golang/go/issues?q=milestone%3AGo1.12.10

Bump golang 1.12.9
=====================================================

go1.12.9 (released 2019/08/15) includes fixes to the linker, and the os and math/big packages.
See the Go 1.12.9 milestone on our issue tracker for details.

https://github.com/golang/go/issues?q=milestone%3AGo1.12.9

Bump golang 1.12.8 (CVE-2019-9512, CVE-2019-9514)
=====================================================

go1.12.8 (released 2019/08/13) includes security fixes to the net/http and net/url packages.
See the Go 1.12.8 milestone on our issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.12.8

- net/http: Denial of Service vulnerabilities in the HTTP/2 implementation
net/http and golang.org/x/net/http2 servers that accept direct connections from untrusted
clients could be remotely made to allocate an unlimited amount of memory, until the program
crashes. Servers will now close connections if the send queue accumulates too many control
messages.
The issues are CVE-2019-9512 and CVE-2019-9514, and Go issue golang.org/issue/33606.
Thanks to Jonathan Looney from Netflix for discovering and reporting these issues.
This is also fixed in version v0.0.0-20190813141303-74dc4d7220e7 of golang.org/x/net/http2.
net/url: parsing validation issue
- url.Parse would accept URLs with malformed hosts, such that the Host field could have arbitrary
suffixes that would appear in neither Hostname() nor Port(), allowing authorization bypasses
in certain applications. Note that URLs with invalid, not numeric ports will now return an error
from url.Parse.
The issue is CVE-2019-14809 and Go issue golang.org/issue/29098.
Thanks to Julian Hector and Nikolai Krein from Cure53, and Adi Cohen (adico.me) for discovering
and reporting this issue.


## Update and pin golang-migrate to v4.6.2

v4.6.2

- Removed unnecessary debug output
- Improved error messages when no migrations are found

v4.6.1

- Fix issue parsing MySQL DSNs with custom query parameters

v4.6.0

- Updated MongoDB driver to v1.1.0
- Missing migrate CLI commands will now return a non-zero exit
- Go 1.12.8 fixed a security issue where invalid URIs were being parsed.
The fix broke migrate when used with MySQL.
- Update NewDockerContainer in unused/deprecated migrate/testing package .


## Use golang-migrate/migrate, because mattes/migrate was archived