### PR TITLE
Add Golang version to version output, and add '--version' flag to binaries

### DIFF
--- a/cmd/notary-server/main.go
+++ b/cmd/notary-server/main.go
@@ -8,6 +8,7 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"runtime"
 
 	"github.com/docker/distribution/health"
 	"github.com/sirupsen/logrus"
@@ -56,7 +57,7 @@ func main() {
 	}
 
 	// when the server starts print the version for debugging and issue logs later
-	logrus.Infof("Version: %s, Git commit: %s", version.NotaryVersion, version.GitCommit)
+	logrus.Infof("Version: %s, Git commit: %s, Go version: %s", version.NotaryVersion, version.GitCommit, runtime.Version())
 
 	ctx, serverConfig, err := parseServerConfig(flagStorage.configFile, health.RegisterPeriodicFunc, flagStorage.doBootstrap)
 	if err != nil {

--- a/cmd/notary-server/main.go
+++ b/cmd/notary-server/main.go
@@ -29,6 +29,7 @@ type cmdFlags struct {
 	logFormat   string
 	configFile  string
 	doBootstrap bool
+	version     bool
 }
 
 func setupFlags(flagStorage *cmdFlags) {
@@ -37,6 +38,7 @@ func setupFlags(flagStorage *cmdFlags) {
 	flag.BoolVar(&flagStorage.debug, "debug", false, "Enable the debugging server on localhost:8080")
 	flag.StringVar(&flagStorage.logFormat, "logf", "json", "Set the format of the logs. Only 'json' and 'logfmt' are supported at the moment.")
 	flag.BoolVar(&flagStorage.doBootstrap, "bootstrap", false, "Do any necessary setup of configured backend storage services")
+	flag.BoolVar(&flagStorage.version, "version", false, "Print the version number of notary-server")
 
 	// this needs to be in init so that _ALL_ logs are in the correct format
 	if flagStorage.logFormat == jsonLogFormat {
@@ -52,12 +54,17 @@ func main() {
 
 	flag.Parse()
 
+	if flagStorage.version {
+		fmt.Println("notary-server " + getVersion())
+		os.Exit(0)
+	}
+
 	if flagStorage.debug {
 		go debugServer(DebugAddress)
 	}
 
 	// when the server starts print the version for debugging and issue logs later
-	logrus.Infof("Version: %s, Git commit: %s, Go version: %s", version.NotaryVersion, version.GitCommit, runtime.Version())
+	logrus.Info(getVersion())
 
 	ctx, serverConfig, err := parseServerConfig(flagStorage.configFile, health.RegisterPeriodicFunc, flagStorage.doBootstrap)
 	if err != nil {
@@ -85,6 +92,10 @@ func main() {
 func usage() {
 	fmt.Println("usage:", os.Args[0])
 	flag.PrintDefaults()
+}
+
+func getVersion() string {
+	return fmt.Sprintf("Version: %s, Git commit: %s, Go version: %s", version.NotaryVersion, version.GitCommit, runtime.Version())
 }
 
 // debugServer starts the debug server with pprof, expvar among other

--- a/cmd/notary-signer/main.go
+++ b/cmd/notary-signer/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	_ "expvar"
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -26,6 +27,7 @@ type cmdFlags struct {
 	logFormat   string
 	configFile  string
 	doBootstrap bool
+	version     bool
 }
 
 func setupFlags(flagStorage *cmdFlags) {
@@ -34,6 +36,7 @@ func setupFlags(flagStorage *cmdFlags) {
 	flag.BoolVar(&flagStorage.debug, "debug", false, "Run in debug mode, enables Go debug server")
 	flag.StringVar(&flagStorage.logFormat, "logf", "json", "Set the format of the logs. Only 'json' and 'logfmt' are supported at the moment.")
 	flag.BoolVar(&flagStorage.doBootstrap, "bootstrap", false, "Do any necessary setup of configured backend storage services")
+	flag.BoolVar(&flagStorage.version, "version", false, "Print the version number of notary-signer")
 
 	// this needs to be in init so that _ALL_ logs are in the correct format
 	if flagStorage.logFormat == jsonLogFormat {
@@ -49,6 +52,11 @@ func main() {
 
 	flag.Parse()
 
+	if flagStorage.version {
+		fmt.Println("notary-signer " + getVersion())
+		os.Exit(0)
+	}
+
 	if flagStorage.debug {
 		go debugServer(debugAddr)
 	} else {
@@ -59,7 +67,7 @@ func main() {
 	}
 
 	// when the signer starts print the version for debugging and issue logs later
-	logrus.Infof("Version: %s, Git commit: %s, Go version: %s", version.NotaryVersion, version.GitCommit, runtime.Version())
+	logrus.Info(getVersion())
 
 	signerConfig, err := parseSignerConfig(flagStorage.configFile, flagStorage.doBootstrap)
 	if err != nil {
@@ -86,6 +94,10 @@ func main() {
 func usage() {
 	log.Println("usage:", os.Args[0], "<config>")
 	flag.PrintDefaults()
+}
+
+func getVersion() string {
+	return fmt.Sprintf("Version: %s, Git commit: %s, Go version: %s", version.NotaryVersion, version.GitCommit, runtime.Version())
 }
 
 // debugServer starts the debug server with pprof, expvar among other

--- a/cmd/notary-signer/main.go
+++ b/cmd/notary-signer/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime"
 
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
@@ -58,7 +59,7 @@ func main() {
 	}
 
 	// when the signer starts print the version for debugging and issue logs later
-	logrus.Infof("Version: %s, Git commit: %s", version.NotaryVersion, version.GitCommit)
+	logrus.Infof("Version: %s, Git commit: %s, Go version: %s", version.NotaryVersion, version.GitCommit, runtime.Version())
 
 	signerConfig, err := parseSignerConfig(flagStorage.configFile, flagStorage.doBootstrap)
 	if err != nil {

--- a/cmd/notary/main.go
+++ b/cmd/notary/main.go
@@ -62,6 +62,7 @@ type notaryCommander struct {
 	// these are for command line parsing - no need to set
 	debug             bool
 	verbose           bool
+	version           bool
 	trustDir          string
 	configFile        string
 	remoteTrustServer string
@@ -144,7 +145,13 @@ func (n *notaryCommander) GetCommand() *cobra.Command {
 		Long:          "Notary allows the creation and management of collections of signed targets, allowing the signing and validation of arbitrary content.",
 		SilenceUsage:  true, // we don't want to print out usage for EVERY error
 		SilenceErrors: true, // we do our own error reporting with fatalf
-		Run:           func(cmd *cobra.Command, args []string) { cmd.Usage() },
+		Run: func(cmd *cobra.Command, args []string) {
+			if n.version {
+				fmt.Printf("notary Version: %s, Git commit: %s, Go version: %s\n", version.NotaryVersion, version.GitCommit, runtime.Version())
+				os.Exit(0)
+			}
+			cmd.Usage()
+		},
 	}
 	notaryCmd.SetOutput(os.Stdout)
 	notaryCmd.AddCommand(&cobra.Command{
@@ -161,6 +168,7 @@ func (n *notaryCommander) GetCommand() *cobra.Command {
 	notaryCmd.PersistentFlags().StringVarP(
 		&n.configFile, "configFile", "c", "", "Path to the configuration file to use")
 	notaryCmd.PersistentFlags().BoolVarP(&n.verbose, "verbose", "v", false, "Verbose output")
+	notaryCmd.Flags().BoolVar(&n.version, "version", false, "Print the version number of notary")
 	notaryCmd.PersistentFlags().BoolVarP(&n.debug, "debug", "D", false, "Debug output")
 	notaryCmd.PersistentFlags().StringVarP(&n.remoteTrustServer, "server", "s", "", "Remote trust server location")
 	notaryCmd.PersistentFlags().StringVar(&n.tlsCAFile, "tlscacert", "", "Trust certs signed only by this CA")

--- a/cmd/notary/main.go
+++ b/cmd/notary/main.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -151,7 +152,7 @@ func (n *notaryCommander) GetCommand() *cobra.Command {
 		Short: "Print the version number of notary",
 		Long:  "Print the version number of notary",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("notary\n Version:    %s\n Git commit: %s\n", version.NotaryVersion, version.GitCommit)
+			fmt.Printf("notary\n Version:    %s\n Git commit: %s\n Go version: %s\n", version.NotaryVersion, version.GitCommit, runtime.Version())
 		},
 	})
 


### PR DESCRIPTION
My lunch project of the day;

With this applied, all binaries now allow printing the version:

```bash
make notary-dockerfile && docker run --rm notary sh -c 'make client && /go/src/github.com/theupdateframework/notary/bin/notary --version && /go/src/github.com/theupdateframework/notary/bin/notary  version' || echo "version failed"
notary Version: 0.6.1, Git commit: d5b73be7, Go version: go1.12.7
# notary
#  Version:    0.6.1
#  Git commit: d5b73be7
#  Go version: go1.12.7

make server-dockerfile && docker run --rm notary-server --version || echo "--version failed"
# notary-server Version: 0.6.1, Git commit: d5b73be7, Go version: go1.11.5


make signer-dockerfile && docker run --rm notary-signer --version || echo "--version failed"
# notary-signer Version: 0.6.1, Git commit: d5b73be7, Go version: go1.11.5 
```
