### PR TITLE
bump miekg/pkcs11 v1.0.2

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -15,7 +15,7 @@ github.com/jinzhu/gorm              5409931a1bb87e484d68d649af9367c207713ea2
 github.com/jinzhu/inflection        1c35d901db3da928c72a72d8458480cc9ade058f
 github.com/lib/pq                   0dad96c0b94f8dee039aa40467f767467392a0af
 github.com/mattn/go-sqlite3         6c771bb9887719704b210e87e934f08be014bdb1 # v1.6.0
-github.com/miekg/pkcs11             553cfdd26aaafe851ca66a5e8015f0decb6b5a1e
+github.com/miekg/pkcs11             cb39313ec884f2cd77f4762875fe96aecf68f8e3 # v1.0.2
 github.com/prometheus/client_golang c332b6f63c0658a65eca15c0e5247ded801cf564
 github.com/prometheus/client_model  99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
 github.com/prometheus/procfs        cb4147076ac75738c9a7d279075a253c0cc5acbd

--- a/vendor/github.com/miekg/pkcs11/go.mod
+++ b/vendor/github.com/miekg/pkcs11/go.mod
@@ -1,0 +1,3 @@
+module github.com/miekg/pkcs11
+
+go 1.12

--- a/vendor/github.com/miekg/pkcs11/release.go
+++ b/vendor/github.com/miekg/pkcs11/release.go
@@ -1,0 +1,17 @@
+// +build release
+
+package pkcs11
+
+import "fmt"
+
+// Release is current version of the pkcs11 library.
+var Release = R{1, 0, 2}
+
+// R holds the version of this library.
+type R struct {
+	Major, Minor, Patch int
+}
+
+func (r R) String() string {
+	return fmt.Sprintf("%d.%d.%d", r.Major, r.Minor, r.Patch)
+}


### PR DESCRIPTION
this package now tags releases; no significant changes otherwise

full diff: https://github.com/miekg/pkcs11/compare/553cfdd26aaafe851ca66a5e8015f0decb6b5a1e...v1.0.2
