### PR TITLE
Add canonical key ID pinning to the trustpin config

### DIFF
--- a/trustpinning/certs.go
+++ b/trustpinning/certs.go
@@ -67,7 +67,11 @@ of the notary client config.  If this section specifies a Certs section with thi
 GUN, we attempt to validate that the certificates present in the downloaded root
 file match the pinned ID.
 
-If the Certs section is empty for this GUN, we check if the trust_pinning
+If the Certs section is empty for this GUN, we check if the trust_pinning section
+specifies a canonical key ID for this GUN.  if so, we specify that the downloaded
+root file as a certificate or root key ID matching this key ID.
+
+If the Certs and KeyID section is empty for this GUN, we check if the trust_pinning
 section specifies a CA section specified in the config for this GUN.  If so, we check
 that the specified CA is valid and has signed a certificate included in the downloaded
 root file.  The specified CA can be a prefix for this GUN.


### PR DESCRIPTION
Signed-off-by: Jameson Hyde <jameson.hyde@docker.com>