### PR TITLE
Fix gosec linter results not being printed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ cross
 *.iml
 *.test
 coverage*.txt
-gas_output.csv
+gosec_output.csv

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,8 @@ endif
 	@test -z "$(shell find . -type f -name "*.go" -not -path "./vendor/*" -not -name "*.pb.*" -exec ineffassign {} \; | tee /dev/stderr)"
 	# gosec - requires that the following be run first:
 	#    go get -u github.com/securego/gosec/cmd/gosec/...
-	@gosec -fmt=csv -out=gas_output.csv -exclude=G104,G304 ./... && test -z "$$(cat gas_output.csv | tee /dev/stderr)"
+	@rm -f gosec_output.csv
+	@gosec -fmt=csv -out=gosec_output.csv -exclude=G104,G304 ./... || (cat gosec_output.csv >&2; exit 1)
 
 build:
 	@echo "+ $@"


### PR DESCRIPTION
Before this, `make lint` would fail, but the output of the linter would be
discarded, making it unclear what caused the failure:

    docker build -t notary_client . && docker run -it --rm -e NOTARY_BUILDTAGS=pkcs11 notary_client sh -c 'make lint'
    ...
    [gosec] 2019/10/16 11:11:04 Checking file: /go/src/github.com/theupdateframework/notary/utils/http.go
    make: *** [Makefile:106: lint] Error 1

This problem occurred, because there was an actual linting error, and
the code to check for failures did so by checking the output of the
csv file to be empty;

    test -z "$$(cat gas_output.csv | tee /dev/stderr)"

In this case, it was not, and the file contained:

    /go/src/github.com/theupdateframework/notary/cmd/notary-server/main.go,8,Profiling endpoint is automatically exposed on /debug/pprof,HIGH,HIGH,"_ ""net/http/pprof"""

In which case, the code tried to evaluated the output;

    "$(echo /go/src/github.com/theupdateframework/notary/cmd/notary-server/main.go,8,Profiling endpoint is automatically exposed on /debug/pprof,HIGH,HIGH,"_ ""net/http/pprof""")"
    bash: /go/src/github.com/theupdateframework/notary/cmd/notary-server/main.go,8,Profiling endpoint is automatically exposed on /debug/pprof,HIGH,HIGH,_ net/http/pprof: No such file or directory

This patch changes the approach, and:

- makes sure no csv file is in place before the test
- using the exit-code of the linter as indication it failed (instead of checking for the file to be empty)
- in which case, the output of the file is printed on stderr, and the script exited with a non-zero status
- renames the csv-file from gas_output.csv to gosec_output.csv, to match the new name of the linter

With this patch applied:

    docker build -t notary_client . && docker run -it --rm -e NOTARY_BUILDTAGS=pkcs11 notary_client sh -c 'make lint'
    ...
    [gosec] 2019/10/16 11:13:20 Checking file: /go/src/github.com/theupdateframework/notary/signer/api/rpc_api.go
    /go/src/github.com/theupdateframework/notary/cmd/notary-server/main.go,8,Profiling endpoint is automatically exposed on /debug/pprof,HIGH,HIGH,"_ ""net/http/pprof"""
    make: *** [Makefile:107: lint] Error 1
