### PR TITLE
gosec: ignore  G108: Profiling endpoint automatically exposed

### DIFF
--- a/cmd/notary-server/main.go
+++ b/cmd/notary-server/main.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
+	_ "net/http/pprof" // #nosec G108 // false positive as it's only listening through debugServer()
 	"os"
 	"os/signal"
 	"runtime"


### PR DESCRIPTION
This was a false positive, as no server is started unless `-debug` is enabled.

Also see https://github.com/theupdateframework/notary/pull/1505, which fixes CI to print the actual failure