### PR TITLE
Fix "make test" broken on Go 1.13

### DIFF
--- a/cmd/escrow/main.go
+++ b/cmd/escrow/main.go
@@ -17,10 +17,10 @@ func init() {
 		"config.toml",
 		"path to configuration file; supported formats are JSON, YAML, and TOML",
 	)
-	flag.Parse()
 }
 
 func main() {
+	flag.Parse()
 	v, err := parseConfig(configPath)
 	if err != nil {
 		logrus.Fatalf("could not parse config file (%s): %s", configPath, err)


### PR DESCRIPTION
This fixes the tests being broken on Go 1.13 and up, which is caused by a change
in Go 1.13: https://golang.org/doc/go1.13#testing

> Testing flags are now registered in the new Init function, which is invoked by
> the generated main function for the test. As a result, testing flags are now only
> registered when running a test binary, and packages that call flag.Parse during
> package initialization may cause tests to fail.

Before this change:

    make test

    ok  	github.com/theupdateframework/notary/client/changelist	(cached)
    flag provided but not defined: -test.testlogfile
    Usage of /var/folders/c_/vjh56sc12fd2b_q2n02_lt140000gn/T/go-build270388911/b229/escrow.test:
      -config string
        	path to configuration file; supported formats are JSON, YAML, and TOML (default "config.toml")
    ...
    FAIL
    make: *** [test] Error 1

With this patch applied, the test complete succesfully
