### PR TITLE
Makefile: disable debug to make CI more readable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ protos:
 # be run first
 gen-cover:
 gen-cover:
-	@python -u buildscripts/covertest.py --tags "$(NOTARY_BUILDTAGS)" --pkgs="$(PKGS)" --testopts="${TESTOPTS}" --debug
+	@python -u buildscripts/covertest.py --tags "$(NOTARY_BUILDTAGS)" --pkgs="$(PKGS)" --testopts="${TESTOPTS}"
 
 # Generates the cover binaries and runs them all in serial, so this can be used
 # run all tests with a yubikey without any problems


### PR DESCRIPTION
CI was quite noisy, and probably could do without the `-debug` option (I think it can still be enabled by setting a `DEBUG` env-var if needed)