### PR TITLE
Remove duplicated words

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2174,7 +2174,7 @@ func createKey(t *testing.T, repo *repository, role data.RoleName, x509 bool) da
 
 // Publishing delegations works so long as the delegation parent exists by the
 // time that delegation addition change is applied.  Most of the tests for
-// applying delegation changes in in helpers_test.go (applyTargets tests), so
+// applying delegation changes in helpers_test.go (applyTargets tests), so
 // this is just a sanity test to make sure Publish calls it correctly
 func TestPublishDelegations(t *testing.T) {
 	testPublishDelegations(t, true, false)

--- a/cmd/notary/integration_test.go
+++ b/cmd/notary/integration_test.go
@@ -417,7 +417,7 @@ func TestClientTUFInteraction(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, output, target2)
 
-	// Check the file this was written to to inspect metadata
+	// Check the file this was written to inspect metadata
 	cache, err := nstorage.NewFileStore(
 		filepath.Join(tempDir, "tuf", filepath.FromSlash("gun"), "metadata"),
 		"json",
@@ -763,7 +763,7 @@ func TestClientTUFAddByHashInteraction(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, output, target4)
 
-	// Check the file this was written to to inspect metadata
+	// Check the file this was written to inspect metadata
 	cache, err := nstorage.NewFileStore(
 		filepath.Join(tempDir, "tuf", filepath.FromSlash("gun"), "metadata"),
 		"json",

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -497,7 +497,7 @@ func (t *tufCommander) tufInit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// if key is not defined but cert is, then clear the key to to allow key to be searched in keystore
+	// if key is not defined but cert is, then clear the key to allow key to be searched in keystore
 	if t.rootKey == "" && t.rootCert != "" {
 		rootKeyIDs = []string{}
 	}

--- a/tuf/signed/sign_test.go
+++ b/tuf/signed/sign_test.go
@@ -69,7 +69,7 @@ func (mts *FailingCryptoService) RemoveKey(keyID string) error {
 	return nil
 }
 
-// A CryptoService which only only allows using one key
+// A CryptoService which only allows using one key
 type MockCryptoService struct {
 	testKey data.PrivateKey
 }


### PR DESCRIPTION
Although it is spelling mistakes, it might make an affects while reading.

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>