### PR TITLE
Bump mariadb from 10.1.28 to 10.4

### DIFF
--- a/development.mysql.yml
+++ b/development.mysql.yml
@@ -33,7 +33,7 @@ services:
       - mdb
     volumes:
       - ./notarysql/mysql-initdb.d:/docker-entrypoint-initdb.d
-    image: mariadb:10.1.28
+    image: mariadb:10.4
     environment:
       - TERM=dumb
       - MYSQL_ALLOW_EMPTY_PASSWORD="true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     volumes:
       - ./notarysql/mysql-initdb.d:/docker-entrypoint-initdb.d
       - notary_data:/var/lib/mysql
-    image: mariadb:10.1.28
+    image: mariadb:10.4
     environment:
       - TERM=dumb
       - MYSQL_ALLOW_EMPTY_PASSWORD="true"


### PR DESCRIPTION
Bumped the mariadb container used in docker-compose to 10.4 docker image.