### PR TITLE
Upgrade docker images to Go 1.13.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.12
+FROM golang:1.13.6
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/cross.Dockerfile
+++ b/cross.Dockerfile
@@ -1,4 +1,4 @@
-FROM dockercore/golang-cross:1.12.12
+FROM dockercore/golang-cross:1.13.6
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/escrow.Dockerfile
+++ b/escrow.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.12-alpine
+FROM golang:1.13.6-alpine
 
 ENV NOTARYPKG github.com/theupdateframework/notary
 

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.12-alpine
+FROM golang:1.13.6-alpine
 
 RUN apk add --update git gcc libc-dev
 

--- a/server.minimal.Dockerfile
+++ b/server.minimal.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.12-alpine AS build-env
+FROM golang:1.13.6-alpine AS build-env
 RUN apk add --update git gcc libc-dev
 
 ARG MIGRATE_VER=v4.6.2

--- a/signer.Dockerfile
+++ b/signer.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.12-alpine
+FROM golang:1.13.6-alpine
 
 RUN apk add --update git gcc libc-dev
 

--- a/signer.minimal.Dockerfile
+++ b/signer.minimal.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.12-alpine AS build-env
+FROM golang:1.13.6-alpine AS build-env
 RUN apk add --update git gcc libc-dev
 
 ARG MIGRATE_VER=v4.6.2


### PR DESCRIPTION
Folllowing PR should make the image for the cross.Dockerfile available

Running the ./build-image.sh from that PR should create it locally on your machine for testing purposes.

https://github.com/docker/golang-cross/pull/49

Depending on the other PR we might also take out that change for the cross.Dockerfile so this PR doesn't remain open for ages.