### PR TITLE
Fix gosec linting errors (fix G306 and G307)

### DIFF
--- a/client/changelist/file_changelist.go
+++ b/client/changelist/file_changelist.go
@@ -35,7 +35,10 @@ func getFileNames(dirName string) ([]os.FileInfo, error) {
 	if err != nil {
 		return fileInfos, err
 	}
-	defer dir.Close()
+	defer func() {
+		_ = dir.Close()
+	}()
+
 	dirListing, err = dir.Readdir(0)
 	if err != nil {
 		return fileInfos, err
@@ -89,7 +92,7 @@ func (cl FileChangelist) Add(c Change) error {
 		return err
 	}
 	filename := fmt.Sprintf("%020d_%s.change", time.Now().UnixNano(), uuid.Generate())
-	return ioutil.WriteFile(filepath.Join(cl.dir, filename), cJSON, 0644)
+	return ioutil.WriteFile(filepath.Join(cl.dir, filename), cJSON, 0600)
 }
 
 // Remove deletes the changes found at the given indices
@@ -120,7 +123,10 @@ func (cl FileChangelist) Clear(archive string) error {
 	if err != nil {
 		return err
 	}
-	defer dir.Close()
+	defer func() {
+		_ = dir.Close()
+	}()
+
 	files, err := dir.Readdir(0)
 	if err != nil {
 		return err

--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -522,7 +522,9 @@ func (k *keyCommander) importKeys(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		defer from.Close()
+		defer func() {
+			_ = from.Close()
+		}()
 		if err = trustmanager.ImportKeys(from, importers, k.importRole, k.keysImportGUN, k.getRetriever()); err != nil {
 			return err
 		}
@@ -551,7 +553,9 @@ func (k *keyCommander) exportKeys(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		defer f.Close()
+		defer func() {
+			_ = f.Close()
+		}()
 		out = f
 	}
 

--- a/cmd/notary/util.go
+++ b/cmd/notary/util.go
@@ -47,7 +47,7 @@ func feedback(t *tufCommander, payload []byte) error {
 
 	// Flag "quiet" was not "true", that's why we get here.
 	if t.output != "" {
-		return ioutil.WriteFile(t.output, payload, 0644)
+		return ioutil.WriteFile(t.output, payload, 0600)
 	}
 
 	os.Stdout.Write(payload)

--- a/storage/filestore.go
+++ b/storage/filestore.go
@@ -144,7 +144,9 @@ func (f *FilesystemStore) GetSized(name string, size int64) ([]byte, error) {
 		}
 		return nil, err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	if size == NoSizeLimit {
 		size = notary.MaxDownloadSize


### PR DESCRIPTION
Carrying the first commit of https://github.com/theupdateframework/notary/pull/1537 (updated the commit message with a description)
