### PR TITLE
Added fuzzer for cryptoservice

### DIFF
--- a/cryptoservice/fuzz/fuzz.go
+++ b/cryptoservice/fuzz/fuzz.go
@@ -1,0 +1,19 @@
+// +build gofuzz
+
+package fuzz
+
+import (
+	"github.com/theupdateframework/notary/cryptoservice"
+	"github.com/theupdateframework/notary/passphrase"
+	"github.com/theupdateframework/notary/trustmanager"
+)
+
+// Fuzz implements the fuzzer that targets GetPrivateKey
+func Fuzz(data []byte) int {
+	cryptos := cryptoservice.NewCryptoService(trustmanager.NewKeyMemoryStore(passphrase.ConstantRetriever("pass")))
+	_, _, err := cryptos.GetPrivateKey(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
This PR adds a fuzzer that targets `GetPrivateKey()`.

The fuzzer runs both locally and on oss-fuzz's infrastructure as well. I suggest integrating Notary into oss-fuzz which will allow Google to run this fuzzer and future fuzzers on their platform continuously. When a bug is found by oss-fuzz, the maintainers on the contact list receive a detailed bug report via email. 
To be part of the project is free. It is expected that the bugs are fixed, so that the resources put into running the fuzzers go to good use.

I will be happy to integrate Notary into oss-fuzz. All I need are the email addresses of maintainers that need to receive the bug reports.