### PR TITLE
Resolve build error with 'make cross'

### DIFF
--- a/cross.Dockerfile
+++ b/cross.Dockerfile
@@ -1,4 +1,4 @@
-FROM dockercore/golang-cross:1.12.15
+FROM dockercore/golang-cross:1.13.14
 
 RUN apt-get update && apt-get install -y \
 	curl \
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN useradd -ms /bin/bash notary \
-	&& pip install codecov \
+	&& python -m pip install -U pip setuptools && pip install codecov \
 	&& go get golang.org/x/lint/golint github.com/fzipp/gocyclo github.com/client9/misspell/cmd/misspell github.com/gordonklaus/ineffassign github.com/securego/gosec/cmd/gosec/...
 
 ENV NOTARYDIR /go/src/github.com/theupdateframework/notary


### PR DESCRIPTION
Due to outdated setuptools the build was failing for 'pip install
codecov'

resolves #1561 