### PR TITLE
yubikey: add library path for arm64

### DIFF
--- a/trustmanager/yubikey/pkcs11_darwin.go
+++ b/trustmanager/yubikey/pkcs11_darwin.go
@@ -6,4 +6,6 @@ var possiblePkcs11Libs = []string{
 	"/usr/local/lib/libykcs11.dylib",
 	"/usr/local/docker/lib/libykcs11.dylib",
 	"/usr/local/docker-experimental/lib/libykcs11.dylib",
+	// default location on arm64
+	"/opt/homebrew/lib/libykcs11.dylib",
 }


### PR DESCRIPTION
`/opt/homebrew` is where pkcs11 libraries are put by default on arm64 https://github.com/Homebrew/install/blob/b62804e014a2d31216e074398411069688517a79/install.sh#L29-L32

I could also put `/usr/local/lib` and `/opt/homebrew` behind different arch buildtags to handle the case where a user could have both native and rosetta toolchains better. But I'm not sure if some users might prefer to still manually use the old path in arm64 as well. I haven't verified that any of this works under rosetta at all.

@justincormack 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>