### PR TITLE
Fix typo on docs/service_architecture.md

### DIFF
--- a/docs/service_architecture.md
+++ b/docs/service_architecture.md
@@ -160,8 +160,8 @@ discusses how our architecture is designed to deal with compromises.
 ### Notary server compromise
 
 In the event of a Notary server compromise, an attacker would have direct access to
-the metadata stored in the database as well as well as access to the credentials
-used to communicate with Notary signer, and therefore, access to arbitrary signing
+the metadata stored in the database as well as access to the credentials used to
+communicate with Notary signer, and therefore, access to arbitrary signing
 operations with any key the Signer holds.
 
 - **Denial of Service** - An attacker could reject client requests and corrupt


### PR DESCRIPTION
Hey there,

This patch changes the string "as well as well as" to "as well as".

It also keeps the text width as 84 chars, which was the width for the updated paragraph before the patch.

Cheers!