### PR TITLE
BUGFIX: Resolve build error with 'make cross'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,21 @@ RUN apt-get update && apt-get install -y \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN useradd -ms /bin/bash notary \
-	&& pip install codecov \
-	&& go get golang.org/x/lint/golint github.com/fzipp/gocyclo github.com/client9/misspell/cmd/misspell github.com/gordonklaus/ineffassign github.com/securego/gosec/cmd/gosec/...
+    && pip install codecov
 
-ENV NOTARYDIR /go/src/github.com/theupdateframework/notary
+ENV GO111MODULE=on
+
+# Locked go cyclo on this commit as newer commits depend on Golang 1.16 io/fs
+RUN go get golang.org/x/lint/golint \
+    github.com/client9/misspell/cmd/misspell \
+    github.com/gordonklaus/ineffassign \
+    github.com/securego/gosec/cmd/gosec/... \
+    github.com/fzipp/gocyclo@ffe36aa317dcbb421a536de071660261136174dd
+
+ENV GOFLAGS=-mod=vendor \
+    NOTARYDIR=/go/src/github.com/theupdateframework/notary
 
 COPY . ${NOTARYDIR}
 RUN chmod -R a+rw /go && chmod 0600 ${NOTARYDIR}/fixtures/database/*
-
-ENV GO111MODULE=on
 
 WORKDIR ${NOTARYDIR}

--- a/cross.Dockerfile
+++ b/cross.Dockerfile
@@ -1,4 +1,4 @@
-FROM dockercore/golang-cross:1.12.15
+FROM dockercore/golang-cross:1.13.15
 
 RUN apt-get update && apt-get install -y \
 	curl \
@@ -14,12 +14,19 @@ RUN apt-get update && apt-get install -y \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN useradd -ms /bin/bash notary \
-	&& pip install codecov \
-	&& go get golang.org/x/lint/golint github.com/fzipp/gocyclo github.com/client9/misspell/cmd/misspell github.com/gordonklaus/ineffassign github.com/securego/gosec/cmd/gosec/...
+    && pip install codecov
 
-ENV NOTARYDIR /go/src/github.com/theupdateframework/notary
 ENV GO111MODULE=on
-ENV GOFLAGS=-mod=vendor
+
+# Locked go cyclo on this commit as newer commits depend on Golang 1.16 io/fs
+RUN go get golang.org/x/lint/golint \
+    github.com/client9/misspell/cmd/misspell \
+    github.com/gordonklaus/ineffassign \
+    github.com/securego/gosec/cmd/gosec/... \
+    github.com/fzipp/gocyclo@ffe36aa317dcbb421a536de071660261136174dd
+
+ENV GOFLAGS=-mod=vendor \
+    NOTARYDIR=/go/src/github.com/theupdateframework/notary
 
 COPY . ${NOTARYDIR}
 RUN chmod -R a+rw /go


### PR DESCRIPTION
The build was failing due to a breaking change to `goclyclo`.

Recently (18 days ago at the time of this writing) `gocyclo` updated to `go1.16` and started using it's `io/fs` package. Due to this `make cross` breaks as it depends on Go `1.12.5`, I took liberty to update it to the latest go `1.13.5` release.

I also had to move the enabling of Go modules to be able to install gocyclo at a specific version/commit.

Also worked a bit on the cache-ability of layers in the image by splitting some RUN statements.